### PR TITLE
fix(bot): registrar primeraVezFlow y seguimientoFlow en createFlow

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
+    "lint": "node --check src/index.js src/flows/appointment.js src/flows/mainMenu.js src/flows/clinicalHistory.js src/flows/registration.js src/flows/knowledgeBase.js src/services/appointmentService.js src/services/fileDb.js src/services/knowledgeBase.js",
     "prepare": "husky"
   },
   "dependencies": {

--- a/bot/src/flows/appointment.js
+++ b/bot/src/flows/appointment.js
@@ -12,7 +12,7 @@ const appointmentFlow = addKeyword(['agendar', 'cita', 'turno', 'reservar'])
         ]
     })
 
-addKeyword('primera vez')
+export const primeraVezFlow = addKeyword(['primera vez', '👤 Primera vez'])
     .addAction(async (ctx, { flowDynamic, state }) => {
         await state.update({ appointmentType: 'primera vez' })
         await flowDynamic('👤 *Primera Consulta*\n\n• Duración: 90 minutos\n• Costo: $60 USD\n\n*¿Cuál es tu nombre completo?*', { capture: true })
@@ -129,7 +129,7 @@ addKeyword('primera vez')
         await state.clear()
     })
 
-addKeyword('seguimiento')
+export const seguimientoFlow = addKeyword(['seguimiento', '🔄 Seguimiento'])
     .addAction(async (ctx, { flowDynamic, state }) => {
         await state.update({ appointmentType: 'seguimiento' })
         await flowDynamic('🔄 *Seguimiento*\n\n• Duración: 50 minutos\n• Costo: $45 USD\n\n*¿Cuál es tu email de registro?*', { capture: true })
@@ -254,4 +254,4 @@ export const cancelAppointmentFlow = addKeyword(['cancelar cita', 'cancelar', 'r
         await flowDynamic('⚠️ *Política*: Cancelaciones con 24h de anticipación.\n\n📧 Tu solicitud ha sido registrada.\n\n*Escribí *menu*.')
     })
 
-export default appointmentFlow
+export { appointmentFlow }

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -4,11 +4,8 @@ import pkg from '@builderbot/provider-wppconnect'
 const { WPPConnectProvider } = pkg
 
 import { mainMenuFlow } from './flows/mainMenu.js'
-import { appointmentFlow } from './flows/appointment.js'
-import { knowledgeBaseFlow } from './flows/knowledgeBase.js'
-import { searchFlow } from './flows/knowledgeBase.js'
-import { appointmentStatusFlow } from './flows/appointment.js'
-import { cancelAppointmentFlow } from './flows/appointment.js'
+import { appointmentFlow, primeraVezFlow, seguimientoFlow, appointmentStatusFlow, cancelAppointmentFlow } from './flows/appointment.js'
+import { knowledgeBaseFlow, searchFlow } from './flows/knowledgeBase.js'
 import { clinicalHistoryFlow } from './flows/clinicalHistory.js'
 import { registrationFlow } from './flows/registration.js'
 
@@ -61,13 +58,15 @@ const main = async () => {
         catchAllFlow,
         helpFlow,
         ...mainMenuFlow,
-        ...appointmentFlow,
+        appointmentFlow,
+        primeraVezFlow,
+        seguimientoFlow,
         appointmentStatusFlow,
         cancelAppointmentFlow,
         knowledgeBaseFlow,
         searchFlow,
-        clinicalHistoryFlow,
-        registrationFlow
+        ...clinicalHistoryFlow,
+        ...registrationFlow
     ])
 
     console.log('🚀 Creando bot...')


### PR DESCRIPTION
## Issues resueltos

Cierra #3 (C-01), #4 (C-02), #5 (C-03), #7 (C-05)

## Cambios

**`bot/src/flows/appointment.js`**
- `primeraVezFlow` y `seguimientoFlow` ahora son constantes exportadas (C-01)
- Keywords actualizados: `["primera vez", "👤 Primera vez"]` y `["seguimiento", "🔄 Seguimiento"]` para que el botón del menú los active
- Cambiado `export default` → `export { appointmentFlow }` (C-05)

**`bot/src/index.js`**
- Imports consolidados en una línea
- Removido spread incorrecto de `...appointmentFlow` → `appointmentFlow` (C-02)
- Agregado spread correcto a `...clinicalHistoryFlow` y `...registrationFlow` (C-03)
- `primeraVezFlow` y `seguimientoFlow` incluidos en `createFlow()`

**`bot/package.json`**
- Agregado script `lint` con `node --check` para que el pre-commit hook de Husky no falle

## Test plan

- [ ] Bot arranca sin errores
- [ ] Escribir "agendar" → muestra menú con botones
- [ ] Click "👤 Primera vez" → dispara `primeraVezFlow`
- [ ] Click "🔄 Seguimiento" → dispara `seguimientoFlow`
- [ ] Escribir "primera vez" directamente → dispara `primeraVezFlow`
- [ ] `pnpm lint` pasa sin errores

https://claude.ai/code/session_01Vho68CtjhxQidvEXV5gQNJ