### PR TITLE
fix(bot): reemplazar operador $ne por filtrado JS nativo en fileDb

### DIFF
--- a/bot/src/services/fileDb.js
+++ b/bot/src/services/fileDb.js
@@ -110,11 +110,8 @@ export const fileDbService = {
     },
 
     async getAppointments(patientId) {
-        const appointments = await jsonDb.find('appointments', {
-            patientId,
-            status: { $ne: 'cancelled' }
-        })
-        return appointments.filter(a => a.patientId === patientId && a.status !== 'cancelled')
+        const all = await jsonDb.get('appointments')
+        return all.filter(a => a.patientId === patientId && a.status !== 'cancelled')
     },
 
     async createAppointment(data) {


### PR DESCRIPTION
## Issue resuelto

Cierra #6 (C-04)

## Problema

`getAppointments()` usaba `jsonDb.find()` con `{ status: { $ne: 'cancelled' } }`. El método `find()` hace comparación estricta `===`, por lo que `item.status === { $ne: 'cancelled' }` siempre es `false` → la función retornaba `[]` siempre.

Además tenía doble filtrado redundante: el `find()` roto seguido de un `.filter()` correcto.

## Cambio

```js
// ANTES (roto)
const appointments = await jsonDb.find('appointments', {
    patientId,
    status: { $ne: 'cancelled' }  // nunca matcheaba
})
return appointments.filter(a => a.patientId === patientId && a.status !== 'cancelled')

// DESPUÉS (correcto)
const all = await jsonDb.get('appointments')
return all.filter(a => a.patientId === patientId && a.status !== 'cancelled')
```

## Test plan

- [x] Bot arranca sin errores
- [x] "mis citas" con email registrado → muestra citas activas
- [x] Citas con status `cancelled` no aparecen en el listado

https://claude.ai/code/session_01Vho68CtjhxQidvEXV5gQNJ