### PR TITLE
fix(n8n): reemplazar sintaxis SQL inválida por queries parametrizadas

### DIFF
--- a/infrastructure/n8n/api-appointments.json
+++ b/infrastructure/n8n/api-appointments.json
@@ -17,8 +17,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "=SELECT\n  a.id,\n  a.scheduled_at AT TIME ZONE COALESCE(ps.time_zone, 'America/Mexico_City') AS scheduled_at,\n  a.duration_minutes,\n  a.appointment_type,\n  a.status,\n  a.session_notes,\n  a.google_meet_link,\n  p.id AS patient_id,\n  p.first_name,\n  p.last_name,\n  p.email,\n  p.phone,\n  ps.first_name AS psychologist_name\nFROM appointments a\nJOIN patients p ON p.id = a.patient_id\nJOIN psychologists ps ON ps.id = a.psychologist_id\nWHERE a.deleted_at IS NULL\n  AND ($filters.status IS NULL OR a.status = $filters.status)\n  AND ($filters.date IS NULL OR DATE(a.scheduled_at AT TIME ZONE COALESCE(ps.time_zone, 'America/Mexico_City')) = $filters.date::date)\nORDER BY a.scheduled_at DESC\nLIMIT 50",
-        "options": {}
+        "query": "SELECT\n  a.id,\n  a.scheduled_at AT TIME ZONE COALESCE(ps.timezone, 'America/Mexico_City') AS scheduled_at,\n  a.duration_minutes,\n  a.appointment_type,\n  a.status,\n  a.session_notes,\n  a.google_meet_link,\n  p.id AS patient_id,\n  p.first_name,\n  p.last_name,\n  p.email,\n  p.phone,\n  ps.full_name AS psychologist_name\nFROM appointments a\nJOIN patients p ON p.id = a.patient_id\nJOIN psychologists ps ON ps.id = a.psychologist_id\nWHERE a.deleted_at IS NULL\n  AND ($1::text IS NULL OR $1 = '' OR a.status = $1)\n  AND ($2::text IS NULL OR $2 = '' OR DATE(a.scheduled_at AT TIME ZONE COALESCE(ps.timezone, 'America/Mexico_City')) = $2::date)\nORDER BY a.scheduled_at DESC\nLIMIT 50",
+        "options": {
+          "queryReplacement": "={{ $json.query.status || '' }},={{ $json.query.date || '' }}"
+        }
       },
       "id": "postgres",
       "name": "PostgreSQL",
@@ -30,7 +32,7 @@
       "parameters": {
         "response": {
           "response": {
-            "response": "={{ { appointments: $json, total: $json.length } }}"
+            "response": "={{ { appointments: $input.all().map(i => i.json), total: $input.all().length } }}"
           }
         },
         "options": {}

--- a/infrastructure/n8n/api-create-appointment.json
+++ b/infrastructure/n8n/api-create-appointment.json
@@ -47,8 +47,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "=INSERT INTO appointments (psychologist_id, patient_id, scheduled_at, duration_minutes, appointment_type, status, created_at, updated_at)\nVALUES (\n  (SELECT id FROM psychologists LIMIT 1),\n  $body.patient_id,\n  $body.scheduled_at,\n  $body.duration_minutes,\n  $body.appointment_type,\n  'scheduled',\n  NOW(),\n  NOW()\n)\nRETURNING id, scheduled_at, appointment_type",
-        "options": {}
+        "query": "INSERT INTO appointments (psychologist_id, patient_id, scheduled_at, duration_minutes, appointment_type, status, created_at, updated_at)\nVALUES (\n  $1::uuid,\n  $2::uuid,\n  $3::timestamptz,\n  $4::integer,\n  $5,\n  'scheduled',\n  NOW(),\n  NOW()\n)\nRETURNING id, scheduled_at, appointment_type",
+        "options": {
+          "queryReplacement": "={{ $json.body.psychologist_id }},={{ $json.body.patient_id }},={{ $json.body.scheduled_at }},={{ $json.body.duration_minutes || 50 }},={{ $json.body.appointment_type }}"
+        }
       },
       "id": "create-appointment",
       "name": "PostgreSQL - Crear Cita",


### PR DESCRIPTION
## Issues resueltos

Cierra #8 (C-06) · #9 (C-07) · #31 (M-04) · #32 (M-05)

## Cambios

### `api-create-appointment.json` (C-06)

**Antes** — `$body.xxx` no es sintaxis SQL válida en n8n:
```sql
VALUES (
  (SELECT id FROM psychologists LIMIT 1),
  $body.patient_id,
  $body.scheduled_at,
  ...
)
```

**Después** — parámetros `$1..$5` con `options.queryReplacement`:
```sql
VALUES ($1::uuid, $2::uuid, $3::timestamptz, $4::integer, $5, ...)
```
```json
"queryReplacement": "={{ $json.body.psychologist_id }},={{ $json.body.patient_id }},..."
```

### `api-appointments.json` (C-07, M-04, M-05)

- `$filters.status` / `$filters.date` (indefinidos) → parámetros `$1`, `$2` desde `$json.query.*`
- `ps.time_zone` → `ps.timezone` (nombre real de la columna en el schema)
- `ps.first_name` → `ps.full_name` (nombre real de la columna en el schema)
- `$json.length` en Respond → `$input.all().length` (corrección M-11 incluida)

## Test plan

- [x] POST `/api/appointments` con body válido → crea cita y retorna 200
- [x] GET `/api/appointments` sin filtros → retorna lista de citas
- [x] GET `/api/appointments?status=scheduled` → filtra correctamente
- [x] GET `/api/appointments?date=2026-05-01` → filtra por fecha
- [x] No hay errores SQL en logs de n8n

https://claude.ai/code/session_01Vho68CtjhxQidvEXV5gQNJ