### PR TITLE
fix(ci): eliminar job n8n sin Dockerfile y unificar secrets Docker Hub

### DIFF
--- a/.github/workflows/bot-ci.yml
+++ b/.github/workflows/bot-ci.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   BOT_IMAGE: ipproyectosysoluciones/asistente-bot
-  DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
 jobs:
   lint:
@@ -82,8 +82,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -26,40 +26,26 @@ jobs:
       - name: Validate docker-compose.yml
         run: |
           cd infrastructure
-          docker-compose config --quiet || echo "docker-compose validation failed"
+          docker-compose config --quiet
 
-      - name: Check PostgreSQL script syntax
+      - name: Validate docker-compose.production.yml
         run: |
-          # Basic validation - PostgreSQL syntax not checked here
-          # Ideally use pgvalidator container for this
-          echo "PostgreSQL init script validated"
+          cd infrastructure
+          docker-compose -f docker-compose.production.yml config --quiet || echo "Production compose validation skipped (requires env vars)"
 
-  build-n8n-image:
-    name: Build n8n Custom Image
+  validate-n8n-workflows:
+    name: Validate n8n Workflow JSON
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: infrastructure
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-      - name: Build n8n image
+      - name: Validate all n8n workflow JSON files
         run: |
-          docker build -t ipproyectosysoluciones/asistente-n8n:latest .
-
-      - name: Push n8n image
-        if: github.event_name != 'pull_request'
-        run: |
-          docker push ipproyectosysoluciones/asistente-n8n:latest
+          echo "Validating n8n workflow JSON files..."
+          for f in infrastructure/n8n/*.json; do
+            python3 -m json.tool "$f" > /dev/null && echo "✅ $f" || { echo "❌ $f"; exit 1; }
+          done
+          echo "All n8n workflows are valid JSON"
 
   backup-test:
     name: Test Backup Script
@@ -68,11 +54,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run backup test
+      - name: Validate backup script syntax
         run: |
-          chmod +x infrastructure/backups/backup.sh
-          # This would require a test database
-          echo "Backup script validated"
+          bash -n infrastructure/backups/backup.sh && echo "✅ backup.sh syntax valid"
 
   security-scan:
     name: Security Scan


### PR DESCRIPTION
## Issues resueltos

Cierra #51 (L-08)

## Problema raíz

El job `Build n8n Custom Image` fallaba porque intentaba `docker build .` en `infrastructure/` donde **no hay ningún Dockerfile**. n8n no tiene imagen custom — usa `n8nio/n8n:latest` directamente desde Docker Hub.

Además, `infrastructure.yml` y `bot-ci.yml` usaban `DOCKER_HUB_USERNAME` / `DOCKER_HUB_TOKEN` mientras que `docker-push.yml` y `SECRETS_SETUP.md` documentan `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`.

## Cambios en `infrastructure.yml`

- ❌ Eliminado job `build-n8n-image` (no existe Dockerfile)
- ✅ Agregado job `validate-n8n-workflows` que valida el JSON de todos los workflows n8n
- ✅ Mejorado `backup-test` para validar sintaxis bash con `bash -n`
- Sin referencias a Docker Hub secrets (no necesarias)

## Cambios en `bot-ci.yml`

- `DOCKER_HUB_USERNAME` → `DOCKERHUB_USERNAME`
- `DOCKER_HUB_TOKEN` → `DOCKERHUB_TOKEN`

## Resultado esperado

El CI en PRs que tocan `infrastructure/**` ahora corre:
- ✅ Validate Docker Compose
- ✅ Validate n8n Workflow JSON  
- ⏭️ Test Backup Script (solo en push a dev, comportamiento correcto)
- ✅ Security Scan
- ✅ Scan for Secrets

https://claude.ai/code/session_01Vho68CtjhxQidvEXV5gQNJ