### PR TITLE
fix(n8n): corregir referencias de nodos, SQL injection y appointmentId

### DIFF
--- a/infrastructure/n8n/agendamiento-flow.json
+++ b/infrastructure/n8n/agendamiento-flow.json
@@ -59,8 +59,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO appointments (psychologist_id, patient_id, scheduled_at, duration_minutes, appointment_type, status, google_calendar_event_id, created_at, updated_at) VALUES ((SELECT id FROM psychologists LIMIT 1), (SELECT id FROM patients WHERE email = '{{$json.body.email}}' LIMIT 1), '{{$json.body.scheduled_at}}', {{$json.body.duration}}, '{{$json.body.type}}', 'scheduled', '{{$json.calendar_event_id}}', NOW(), NOW())",
-        "options": {}
+        "query": "INSERT INTO appointments (psychologist_id, patient_id, scheduled_at, duration_minutes, appointment_type, status, google_calendar_event_id, created_at, updated_at)\nVALUES (\n  $1::uuid,\n  (SELECT id FROM patients WHERE email = $2 LIMIT 1),\n  $3::timestamptz,\n  $4::integer,\n  $5,\n  'scheduled',\n  $6,\n  NOW(),\n  NOW()\n)\nRETURNING id, scheduled_at, appointment_type",
+        "options": {
+          "queryReplacement": "={{ $json.body.psychologist_id }},={{ $json.body.email }},={{ $json.body.scheduled_at }},={{ $json.body.duration || 50 }},={{ $json.body.type }},={{ $json.calendar_event_id || null }}"
+        }
       },
       "id": "create-appointment",
       "name": "PostgreSQL - Crear Cita",
@@ -136,7 +138,7 @@
         ],
         [
           {
-            "node": "Email - No Disponible",
+            "node": "Gmail - No Disponible",
             "type": "main"
           }
         ]
@@ -153,7 +155,7 @@
     "Google Calendar - Crear Evento": {
       "main": [[
         {
-          "node": "Email - Confirmación",
+          "node": "Gmail - Confirmación",
           "type": "main"
         }
       ]]

--- a/infrastructure/n8n/api-create-patient.json
+++ b/infrastructure/n8n/api-create-patient.json
@@ -17,8 +17,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "=INSERT INTO patients (first_name, last_name, email, phone, consent_status, created_at, updated_at)\nVALUES (\n  $body.first_name,\n  $body.last_name,\n  $body.email,\n  $body.phone,\n  'pending',\n  NOW(),\n  NOW()\n)\nRETURNING id, first_name, last_name, email",
-        "options": {}
+        "query": "INSERT INTO patients (psychologist_id, first_name, last_name, email, phone, consent_status, created_at, updated_at)\nVALUES ($1::uuid, $2, $3, $4, $5, 'pending', NOW(), NOW())\nRETURNING id, first_name, last_name, email",
+        "options": {
+          "queryReplacement": "={{ $json.body.psychologist_id }},={{ $json.body.first_name }},={{ $json.body.last_name }},={{ $json.body.email }},={{ $json.body.phone }}"
+        }
       },
       "id": "create-patient",
       "name": "PostgreSQL - Crear Paciente",

--- a/infrastructure/n8n/confirmacion.json
+++ b/infrastructure/n8n/confirmacion.json
@@ -38,7 +38,7 @@
     },
     {
       "parameters": {
-        "jsCode": "=const body = $input.item.json.text || $input.item.json.body || '';\nconst normalized = body.toUpperCase().normalize('NFD').replace(/[\\u0300-\\u036f]/g, '');\n\n$input.item.json.action = null;\n\nif (normalized.includes('CONFIRMAR')) {\n  $input.item.json.action = 'confirmar';\n} else if (normalized.includes('CANCELAR')) {\n  $input.item.json.action = 'cancelar';\n}\n\nreturn $input.item;",
+        "jsCode": "const body = $input.item.json.text || $input.item.json.body || '';\nconst subject = $input.item.json.subject || '';\nconst normalized = body.toUpperCase().normalize('NFD').replace(/[\\u0300-\\u036f]/g, '');\n\n// Extraer appointmentId del asunto: formato [ID:uuid]\nconst idMatch = subject.match(/\\[ID:([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]/i);\n$input.item.json.appointmentId = idMatch ? idMatch[1] : null;\n$input.item.json.action = null;\n\nif (normalized.includes('CONFIRMAR')) {\n  $input.item.json.action = 'confirmar';\n} else if (normalized.includes('CANCELAR')) {\n  $input.item.json.action = 'cancelar';\n}\n\nreturn $input.item;",
         "options": {}
       },
       "id": "parse-action",
@@ -78,8 +78,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "=UPDATE appointments\nSET status = 'confirmed',\n       updated_at = NOW()\nWHERE id = '{{ $json.appointmentId }}'",
-        "options": {}
+        "query": "UPDATE appointments SET status = 'confirmed', updated_at = NOW() WHERE id = $1::uuid",
+        "options": {
+          "queryReplacement": "={{ $json.appointmentId }}"
+        }
       },
       "id": "confirmar",
       "name": "PostgreSQL - Confirmar",
@@ -103,8 +105,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "=UPDATE appointments\nSET status = 'cancelled',\n       updated_at = NOW()\nWHERE id = '{{ $json.appointmentId }}'",
-        "options": {}
+        "query": "UPDATE appointments SET status = 'cancelled', updated_at = NOW() WHERE id = $1::uuid",
+        "options": {
+          "queryReplacement": "={{ $json.appointmentId }}"
+        }
       },
       "id": "cancelar",
       "name": "PostgreSQL - Cancelar",

--- a/infrastructure/n8n/no-show.json
+++ b/infrastructure/n8n/no-show.json
@@ -33,8 +33,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "=UPDATE appointments\nSET status = 'no_show',\n       updated_at = NOW()\nWHERE id = {{ $json.id }}",
-        "options": {}
+        "query": "UPDATE appointments SET status = 'no_show', updated_at = NOW() WHERE id = $1::uuid",
+        "options": {
+          "queryReplacement": "={{ $json.id }}"
+        }
       },
       "id": "mark-noshow",
       "name": "PostgreSQL - Marcar No-Show",

--- a/infrastructure/n8n/recordatorios.json
+++ b/infrastructure/n8n/recordatorios.json
@@ -21,7 +21,7 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "SELECT\n  a.id,\n  a.scheduled_at AT TIME ZONE COALESCE(ps.time_zone, 'America/Mexico_City') AS scheduled_at,\n  p.first_name,\n  p.last_name,\n  p.email,\n  p.phone,\n  a.appointment_type,\n  a.google_meet_link,\n  ps.time_zone,\n  EXTRACT(EPOCH FROM (a.scheduled_at - NOW())) / 3600 AS hours_until,\n  TO_CHAR(a.scheduled_at AT TIME ZONE COALESCE(ps.time_zone, 'America/Mexico_City'), 'YYYY-MM-DD') AS date,\n  TO_CHAR(a.scheduled_at AT TIME ZONE COALESCE(ps.time_zone, 'America/Mexico_City'), 'HH24:MI') AS time\nFROM appointments a\nJOIN patients p ON a.patient_id = p.id\nJOIN psychologists ps ON ps.id = a.psychologist_id\nWHERE\n  a.status IN ('scheduled', 'confirmed')\n  AND a.deleted_at IS NULL\n  AND a.scheduled_at BETWEEN NOW() AND NOW() + INTERVAL '25 hours'\n  AND a.scheduled_at > NOW()",
+        "query": "SELECT\n  a.id,\n  a.scheduled_at AT TIME ZONE COALESCE(ps.timezone, 'America/Mexico_City') AS scheduled_at,\n  p.first_name,\n  p.last_name,\n  p.email,\n  p.phone,\n  a.appointment_type,\n  a.google_meet_link,\n  ps.timezone,\n  EXTRACT(EPOCH FROM (a.scheduled_at - NOW())) / 3600 AS hours_until,\n  TO_CHAR(a.scheduled_at AT TIME ZONE COALESCE(ps.timezone, 'America/Mexico_City'), 'YYYY-MM-DD') AS date,\n  TO_CHAR(a.scheduled_at AT TIME ZONE COALESCE(ps.timezone, 'America/Mexico_City'), 'HH24:MI') AS time\nFROM appointments a\nJOIN patients p ON a.patient_id = p.id\nJOIN psychologists ps ON ps.id = a.psychologist_id\nWHERE\n  a.status IN ('scheduled', 'confirmed')\n  AND a.deleted_at IS NULL\n  AND a.scheduled_at BETWEEN NOW() AND NOW() + INTERVAL '25 hours'\n  AND a.scheduled_at > NOW()",
         "options": {}
       },
       "id": "get-appointments",
@@ -113,7 +113,7 @@
     {
       "parameters": {
         "to": "={{ $json.email }}",
-        "subject": "📅 Recordatorio: Tu cita es mañana",
+        "subject": "=📅 Recordatorio: Tu cita es mañana [ID:{{ $json.id }}]",
         "body": "=Hola {{ $json.first_name }},\n\nTe recordamos que tienes una cita *mañana*.\n\n📅 Fecha: {{ $json.date }}\n⏰ Hora: {{ $json.time }}\n📋 Tipo: {{ $json.appointment_type }}\n{{ $json.google_meet_link ? '\n🔗 Meet: ' + $json.google_meet_link : '' }}\n\nPor favor confirma tu asistencia respondiendo *CONFIRMAR* o *CANCELAR*.\n\nSi no confirmas con 24h de anticipación, la cita podría liberarse.\n\nSaludos",
         "options": {}
       },


### PR DESCRIPTION
## Issues resueltos

Cierra #10 (C-08) · #11 (C-09) · #12 (C-10) · #13 (C-11) · #32 (M-05 recordatorios)

## Cambios por archivo

### `agendamiento-flow.json` (C-08, H-08)
- ✅ `"Email - No Disponible"` → `"Gmail - No Disponible"` en connections
- ✅ `"Email - Confirmación"` → `"Gmail - Confirmación"` en connections
- ✅ INSERT con SQL injection reemplazado por query parametrizada `$1..$6`

### `no-show.json` (C-10)
- ✅ `WHERE id = {{ $json.id }}` (UUID sin comillas) → `WHERE id = $1::uuid` parametrizado

### `api-create-patient.json` (C-11)
- ✅ Agregado `psychologist_id` (NOT NULL) al INSERT de pacientes
- ✅ `$body.xxx` → parámetros `$1..$5` con `queryReplacement`

### `confirmacion.json` (C-09)
- ✅ Code node extrae `appointmentId` del asunto con regex `[ID:uuid]`
- ✅ UPDATE queries con `{{ $json.appointmentId }}` → parametrizadas con `$1::uuid`

### `recordatorios.json` (C-09, M-05)
- ✅ Asunto del recordatorio 24h incluye `[ID:{{ $json.id }}]` para que el reply sea parseable
- ✅ `ps.time_zone` → `ps.timezone` (nombre real de la columna)

## Flujo de confirmación corregido

```
1. recordatorios.json envía: "📅 Tu cita es mañana [ID:abc-123-def]"
2. Paciente responde: "CONFIRMAR"
3. confirmacion.json extrae ID del asunto del email original
4. UPDATE appointments SET status = confirmed WHERE id = $1::uuid
```

## Test plan

- [ ] Importar agendamiento-flow.json en n8n → conecta correctamente a Gmail
- [ ] POST /webhook/agendar con datos válidos → cita creada sin error SQL
- [ ] Schedule no-show → UPDATE funciona sin error de sintaxis UUID
- [ ] POST /webhook/patients con psychologist_id → paciente creado
- [ ] Email de recordatorio incluye `[ID:uuid]` en el asunto
- [ ] Reply con CONFIRMAR → appointments.status = confirmed

https://claude.ai/code/session_01Vho68CtjhxQidvEXV5gQNJ