### PR TITLE
fix(n8n): SQL injection en whatsapp-new-patient y google-sheets-sync

### DIFF
--- a/infrastructure/n8n/google-sheets-sync.json
+++ b/infrastructure/n8n/google-sheets-sync.json
@@ -43,7 +43,7 @@
               {
                 "id": "condition",
                 "name": "Condition",
-                "value1": "={{ $json.length }}",
+                "value1": "={{ $input.all().length }}",
                 "operation": "gt",
                 "value2": 0
               }
@@ -78,8 +78,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "UPDATE appointments SET updated_at = NOW() WHERE id IN ({{ $json.map(x => x.id).join(',') }})",
-        "options": {}
+        "query": "UPDATE appointments SET updated_at = NOW() WHERE id = ANY($1::uuid[])",
+        "options": {
+          "queryReplacement": "={{ '{' + $input.all().map(x => x.json.id).join(',') + '}' }}"
+        }
       },
       "id": "mark-synced",
       "name": "PostgreSQL - Mark synced",
@@ -90,8 +92,8 @@
     {
       "parameters": {
         "to": "{{ $env.NOTIFICATION_EMAIL }}",
-        "subject": "📊 Sync: {{ $json.length }} nuevas citas",
-        "body": "={{ $json.length + ' nuevas citas sincronizadas a Google Sheets. \n\n' + $json.map(x => x.scheduled_at + ' - ' + x.first_name + ' ' + x.last_name + ' (' + x.appointment_type + ')').join('\n') }}",
+        "subject": "={{ '📊 Sync: ' + $input.all().length + ' nuevas citas' }}",
+        "body": "={{ $input.all().length + ' nuevas citas sincronizadas a Google Sheets. \n\n' + $input.all().map(x => x.json.scheduled_at + ' - ' + x.json.first_name + ' ' + x.json.last_name + ' (' + x.json.appointment_type + ')').join('\n') }}",
         "options": {}
       },
       "id": "email-notify",

--- a/infrastructure/n8n/whatsapp-new-patient.json
+++ b/infrastructure/n8n/whatsapp-new-patient.json
@@ -18,8 +18,10 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "INSERT INTO patients (first_name, last_name, email, phone, country, psychologist_id, created_at, updated_at) VALUES ('{{$json.body.first_name}}', '{{$json.body.last_name}}', '{{$json.body.email}}', '{{$json.body.phone}}', '{{$json.body.country}}', (SELECT id FROM psychologists LIMIT 1), NOW(), NOW())",
-        "options": {}
+        "query": "INSERT INTO patients (first_name, last_name, email, phone, country, psychologist_id, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, (SELECT id FROM psychologists LIMIT 1), NOW(), NOW())",
+        "options": {
+          "queryReplacement": "={{ $json.body.first_name }},={{ $json.body.last_name }},={{ $json.body.email }},={{ $json.body.phone }},={{ $json.body.country }}"
+        }
       },
       "id": "postgres-insert",
       "name": "PostgreSQL - Insert Patient",


### PR DESCRIPTION
## Resumen

- **H-07** `whatsapp-new-patient.json`: El INSERT usaba interpolación directa `'{{$json.body.first_name}}'` etc., vulnerable a SQL injection. Reemplazado con placeholders `$1..$5` y `queryReplacement`.
- **H-09** `google-sheets-sync.json`: El UPDATE usaba `WHERE id IN ({{ $json.map(x => x.id).join(',') }})` con UUIDs sin comillas. Reemplazado con `WHERE id = ANY($1::uuid[])` y `queryReplacement` usando `$input.all()`. También corregidos `$json.length` / `$json.map()` → `$input.all().length` / `$input.all().map()` en nodo IF y email.

## Plan de prueba

- [ ] JSON válido: `python3 -m json.tool` pasa en ambos archivos
- [ ] Payload con comillas simples no rompe el INSERT en whatsapp-new-patient
- [ ] google-sheets-sync UPDATE y email usan `$input.all()` correctamente

https://claude.ai/code/session_01Vho68CtjhxQidvEXV5gQNJ