### PR TITLE
fix(bot): credenciales hardcodeadas y .env.example desalineado

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -2,12 +2,11 @@
 # Asistente Psicológico - Bot Environment
 # ============================================
 
-# PostgreSQL
-DB_HOST=localhost
-DB_PORT=5432
-DB_NAME=asistente_psicologico
-DB_USER=admin
-DB_PASSWORD=changeme123
+# PostgreSQL (required)
+DATABASE_URL=postgresql://user:password@localhost:5432/asistente_psicologico
+
+# Psychologist (required)
+DEFAULT_PSYCHOLOGIST_ID=00000000-0000-0000-0000-000000000000
 
 # n8n Webhook
 N8N_WEBHOOK_URL=http://localhost:5678/webhook

--- a/bot/src/services/appointmentService.js
+++ b/bot/src/services/appointmentService.js
@@ -2,8 +2,12 @@ import pg from 'pg'
 
 const { Pool } = pg
 
+if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL environment variable is required')
+}
+
 const pool = new Pool({
-    connectionString: process.env.DATABASE_URL || 'postgresql://admin:admin@localhost:5432/asistente_psicologico'
+    connectionString: process.env.DATABASE_URL
 })
 
 export const BUSINESS_HOURS = {

--- a/bot/src/services/knowledgeBase.js
+++ b/bot/src/services/knowledgeBase.js
@@ -2,8 +2,12 @@ import pg from 'pg'
 
 const { Pool } = pg
 
+if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL environment variable is required')
+}
+
 const pool = new Pool({
-    connectionString: process.env.DATABASE_URL || 'postgresql://admin:admin@localhost:5432/asistente_psicologico'
+    connectionString: process.env.DATABASE_URL
 })
 
 export const knowledgeService = {


### PR DESCRIPTION
## Resumen

- **H-05** `appointmentService.js` y `knowledgeBase.js`: El fallback `postgresql://admin:admin@...` exponía credenciales por defecto en el repo. Si `DATABASE_URL` no está configurada la app ahora falla con un error claro en lugar de conectar silenciosamente con credenciales inseguras.
- **H-06** `bot/.env.example`: Las variables `DB_HOST`/`DB_PORT`/`DB_USER`/`DB_PASSWORD` no coincidían con lo que el código lee (`DATABASE_URL`). Corregido para usar `DATABASE_URL` y agregado `DEFAULT_PSYCHOLOGIST_ID` que faltaba.

## Plan de prueba

- [ ] Arrancar el bot **sin** `DATABASE_URL` → debe lanzar `Error: DATABASE_URL environment variable is required` y no iniciar
- [ ] Arrancar con `DATABASE_URL` válida → conecta normalmente
- [ ] Verificar que `.env.example` tiene todas las variables que el código necesita

https://claude.ai/code/session_01Vho68CtjhxQidvEXV5gQNJ