### PR TITLE
fix(dashboard): reemplazar fetch() con cliente axios en todas las páginas

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -15,25 +15,21 @@ api.interceptors.response.use(
 
 export const appointmentApi = {
   async list(params: Record<string, string> = {}) {
-    const { data } = await axios.get('/api/appointments', { baseURL: import.meta.env.VITE_API_URL || '', params })
-    return data
+    return api.get('/appointments', { params })
   },
 
   async getStats() {
-    const { data } = await axios.get('/api/stats', { baseURL: import.meta.env.VITE_API_URL || '' })
-    return data
+    return api.get('/stats')
   }
 }
 
 export const patientApi = {
   async list(params: Record<string, string> = {}) {
-    const { data } = await axios.get('/api/patients', { baseURL: import.meta.env.VITE_API_URL || '', params })
-    return data
+    return api.get('/patients', { params })
   },
 
   async get(id: string) {
-    const { data } = await axios.get(`/api/patients/${id}`, { baseURL: import.meta.env.VITE_API_URL || '' })
-    return data
+    return api.get(`/patients/${id}`)
   }
 }
 

--- a/dashboard/src/pages/appointments/AppointmentsPage.tsx
+++ b/dashboard/src/pages/appointments/AppointmentsPage.tsx
@@ -14,32 +14,18 @@ import {
 } from '@/components/ui/table'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Badge } from '@/components/ui/badge'
+import api from '@/lib/api'
 
 async function fetchAppointments() {
-  const res = await fetch('/api/appointments', {
-    baseURL: import.meta.env.VITE_API_URL || ''
-  })
-  if (!res.ok) throw new Error('Error fetching appointments')
-  return res.json()
+  return api.get('/appointments')
 }
 
 async function fetchPatients() {
-  const res = await fetch('/api/patients', {
-    baseURL: import.meta.env.VITE_API_URL || ''
-  })
-  if (!res.ok) throw new Error('Error fetching patients')
-  return res.json()
+  return api.get('/patients')
 }
 
 async function createAppointment(data: AppointmentForm) {
-  const res = await fetch('/api/appointments', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-    baseURL: import.meta.env.VITE_API_URL || ''
-  })
-  if (!res.ok) throw new Error('Error creating appointment')
-  return res.json()
+  return api.post('/appointments', data)
 }
 
 interface AppointmentForm {

--- a/dashboard/src/pages/capture/CapturePage.tsx
+++ b/dashboard/src/pages/capture/CapturePage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Send } from 'lucide-react'
+import api from '@/lib/api'
 
 export default function CapturePage() {
   const navigate = useNavigate()
@@ -17,21 +18,13 @@ export default function CapturePage() {
     const phone = formData.get('phone') as string
 
     try {
-      const res = await fetch('/api/leads', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          first_name: formData.get('first_name'),
-          last_name: formData.get('last_name'),
-          phone,
-          email: formData.get('email'),
-          source: 'web_capture'
-        })
+      await api.post('/leads', {
+        first_name: formData.get('first_name'),
+        last_name: formData.get('last_name'),
+        phone,
+        email: formData.get('email'),
+        source: 'web_capture'
       })
-
-      if (!res.ok) {
-        throw new Error('Error al enviar')
-      }
 
       setSubmitted(true)
     } catch (err) {

--- a/dashboard/src/pages/dashboard/DashboardPage.tsx
+++ b/dashboard/src/pages/dashboard/DashboardPage.tsx
@@ -2,13 +2,10 @@ import { useQuery } from '@tanstack/react-query'
 import { CalendarDays, Users, CheckCircle, XCircle, TrendingUp } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import api from '@/lib/api'
 
 async function fetchStats() {
-  const res = await fetch('/api/stats', {
-    baseURL: import.meta.env.VITE_API_URL || ''
-  })
-  if (!res.ok) throw new Error('Error fetching stats')
-  return res.json()
+  return api.get('/stats')
 }
 
 function StatCard({ title, value, description, icon: Icon, accent = 'text-primary' }: {

--- a/dashboard/src/pages/leads/LeadsPage.tsx
+++ b/dashboard/src/pages/leads/LeadsPage.tsx
@@ -14,24 +14,14 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow
 } from '@/components/ui/table'
 import { Skeleton } from '@/components/ui/skeleton'
+import api from '@/lib/api'
 
 async function fetchLeads() {
-  const res = await fetch('/api/leads', {
-    baseURL: import.meta.env.VITE_API_URL || ''
-  })
-  if (!res.ok) throw new Error('Error fetching leads')
-  return res.json()
+  return api.get('/leads')
 }
 
 async function createLead(data: LeadForm) {
-  const res = await fetch('/api/leads', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-    baseURL: import.meta.env.VITE_API_URL || ''
-  })
-  if (!res.ok) throw new Error('Error creating lead')
-  return res.json()
+  return api.post('/leads', data)
 }
 
 interface LeadForm {

--- a/dashboard/src/pages/patients/PatientsPage.tsx
+++ b/dashboard/src/pages/patients/PatientsPage.tsx
@@ -14,24 +14,14 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Badge } from '@/components/ui/badge'
 import { format } from 'date-fns'
 import { es } from 'date-fns/locale'
+import api from '@/lib/api'
 
 async function fetchPatients() {
-  const res = await fetch('/api/patients', {
-    baseURL: import.meta.env.VITE_API_URL || ''
-  })
-  if (!res.ok) throw new Error('Error fetching patients')
-  return res.json()
+  return api.get('/patients')
 }
 
 async function createPatient(data: PatientForm) {
-  const res = await fetch('/api/patients', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(data),
-    baseURL: import.meta.env.VITE_API_URL || ''
-  })
-  if (!res.ok) throw new Error('Error creating patient')
-  return res.json()
+  return api.post('/patients', data)
 }
 
 interface PatientForm {


### PR DESCRIPTION
## Resumen

**H-10**: `fetch()` no soporta la opción `baseURL` (esa es sintaxis de axios). Todos los requests ignoraban `VITE_API_URL` y siempre iban a `/api` relativo, fallando en producción cuando el frontend está en un origen diferente a la API.

- Reemplazados los 9 `fetch()` en 5 páginas por la instancia axios de `lib/api.ts`
- Corregido `lib/api.ts`: `appointmentApi` y `patientApi` usaban `axios` global en lugar de la instancia configurada, saltándose el `baseURL` y el timeout de 10s

**Archivos modificados:**
- `dashboard/src/lib/api.ts`
- `dashboard/src/pages/dashboard/DashboardPage.tsx`
- `dashboard/src/pages/leads/LeadsPage.tsx`
- `dashboard/src/pages/patients/PatientsPage.tsx`
- `dashboard/src/pages/appointments/AppointmentsPage.tsx`
- `dashboard/src/pages/capture/CapturePage.tsx`

## Plan de prueba

- [x] `grep -r "fetch(" dashboard/src/pages/` → sin resultados
- [x] Configurar `VITE_API_URL=http://api.example.com` y verificar que los requests van al host correcto
- [x] Verificar que errores de red muestran el mensaje del interceptor en consola

https://claude.ai/code/session_01Vho68CtjhxQidvEXV5gQNJ