### PR TITLE
fix(bot): unificar almacenamiento de pacientes a PostgreSQL

### DIFF
--- a/bot/src/flows/appointment.js
+++ b/bot/src/flows/appointment.js
@@ -1,6 +1,5 @@
 import { addAnswer, addKeyword } from '@builderbot/bot'
 import { appointmentService, DURATIONS } from '../services/appointmentService.js'
-import { fileDbService } from '../services/fileDb.js'
 
 const appointmentFlow = addKeyword(['agendar', 'cita', 'turno', 'reservar'])
     .addAnswer('📅 *Agendar Cita*\n\nHorario de atención:\n• Martes a Domingo\n• 09:00 a 18:00\n• Lunch: 12:00 a 13:00\n\n*Duración:*\n• Primera vez: 90 min\n• Seguimiento: 50 min\n\n*¿Qué tipo de consulta necesitas?*', {
@@ -84,19 +83,19 @@ export const primeraVezFlow = addKeyword(['primera vez', '👤 Primera vez'])
         }
 
         try {
-            let patient = await fileDbService.findPatientByEmail(stateData.email)
+            const psychologistId = process.env.DEFAULT_PSYCHOLOGIST_ID
+            let patient = await appointmentService.findPatientByEmail(stateData.email)
             if (!patient) {
-                await fileDbService.savePatient({
+                patient = await appointmentService.createPatient({
                     fullName: stateData.fullName,
                     email: stateData.email,
-                    source: 'whatsapp'
+                    psychologistId
                 })
-                patient = await fileDbService.findPatientByEmail(stateData.email)
             }
 
             await appointmentService.createAppointment({
-                psychologistId: process.env.DEFAULT_PSYCHOLOGIST_ID,
-                patientId: patient?.id,
+                psychologistId,
+                patientId: patient.id,
                 scheduledAt: stateData.scheduledAt,
                 appointmentType: 'primera vez'
             })
@@ -182,7 +181,7 @@ export const seguimientoFlow = addKeyword(['seguimiento', '🔄 Seguimiento'])
         }
 
         try {
-            const patient = await fileDbService.findPatientByEmail(stateData.email)
+            const patient = await appointmentService.findPatientByEmail(stateData.email)
 
             await appointmentService.createAppointment({
                 psychologistId: process.env.DEFAULT_PSYCHOLOGIST_ID,
@@ -209,7 +208,7 @@ export const seguimientoFlow = addKeyword(['seguimiento', '🔄 Seguimiento'])
 export const appointmentStatusFlow = addKeyword(['mis citas', 'ver cita', 'mi cita', 'citas'])
     .addAnswer('📅 *Tus Citas*\n\n*Escribí tu email:*', { capture: true }, async (ctx, { flowDynamic }) => {
         const email = ctx.body.trim()
-        const patient = await fileDbService.findPatientByEmail(email)
+        const patient = await appointmentService.findPatientByEmail(email)
 
         if (!patient) {
             await flowDynamic('📭 No encontré citas para ese email.\n\nEscribí *menu*.')
@@ -245,7 +244,7 @@ export const appointmentStatusFlow = addKeyword(['mis citas', 'ver cita', 'mi ci
 export const cancelAppointmentFlow = addKeyword(['cancelar cita', 'cancelar', 'reagendar'])
     .addAnswer('📅 *Cancelar Cita*\n\nEscribí tu email de registro:', { capture: true }, async (ctx, { flowDynamic }) => {
         const email = ctx.body.trim()
-        const patient = await fileDbService.findPatientByEmail(email)
+        const patient = await appointmentService.findPatientByEmail(email)
 
         if (!patient) {
             await flowDynamic('📭 No encontré un paciente con ese email.\n\nEscribí *menu*.')

--- a/bot/src/services/appointmentService.js
+++ b/bot/src/services/appointmentService.js
@@ -161,6 +161,30 @@ export const appointmentService = {
         return result.rows[0]
     },
 
+    async findPatientByEmail(email) {
+        const result = await pool.query(
+            `SELECT id, first_name, last_name, email
+             FROM patients
+             WHERE email = $1 AND deleted_at IS NULL
+             LIMIT 1`,
+            [email.toLowerCase()]
+        )
+        return result.rows[0] || null
+    },
+
+    async createPatient({ fullName, email, phone, psychologistId }) {
+        const nameParts = (fullName || '').trim().split(' ')
+        const firstName = nameParts[0] || ''
+        const lastName = nameParts.slice(1).join(' ') || ''
+        const result = await pool.query(
+            `INSERT INTO patients (psychologist_id, first_name, last_name, email, phone, consent_status, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, 'pending', NOW(), NOW())
+             RETURNING id, first_name, last_name, email`,
+            [psychologistId, firstName, lastName, email?.toLowerCase(), phone || null]
+        )
+        return result.rows[0]
+    },
+
     validateTimeSlot(dateStr, hourStr) {
         const [year, month, day] = dateStr.split('-').map(Number)
         const scheduledAt = new Date(year, month - 1, day, ...hourStr.split(':').map(Number))


### PR DESCRIPTION
## Resumen

**H-02**: El bot guardaba pacientes en un archivo JSON local (`fileDb`) pero las citas iban a PostgreSQL. El UUID del JSON no existe en la tabla `patients` de Postgres, causando una violación de FK en cada INSERT de cita.

### Cambios

**`appointmentService.js`** — dos funciones nuevas:
- `findPatientByEmail(email)` — busca en Postgres por email
- `createPatient({ fullName, email, phone, psychologistId })` — inserta en Postgres y retorna el registro con UUID real

**`appointment.js`** — eliminada dependencia de `fileDb`:
- `fileDbService.findPatientByEmail()` → `appointmentService.findPatientByEmail()`
- `fileDbService.savePatient()` → `appointmentService.createPatient()`
- Afecta `primeraVezFlow`, `seguimientoFlow`, `appointmentStatusFlow`, `cancelAppointmentFlow`

## Plan de prueba

- [x] Agendar una primera vez con email nuevo → paciente creado en Postgres → cita insertada sin error FK
- [x] Agendar con email existente → paciente encontrado en Postgres → cita asociada correctamente
- [x] Verificar `SELECT * FROM patients` y `SELECT * FROM appointments` en Postgres después de cada booking

https://claude.ai/code/session_01Vho68CtjhxQidvEXV5gQNJ