### PR TITLE
fix: issues M-01 M-06 M-07 M-09 M-12 M-13

### DIFF
--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -10,7 +10,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
-    "jsx": "react-compiler",
+    "jsx": "react-jsx",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/infrastructure/backups/backup.sh
+++ b/infrastructure/backups/backup.sh
@@ -9,29 +9,31 @@ BACKUP_DIR="$(dirname "$0")/../backups/data"
 DATE=$(date +%Y%m%d_%H%M%S)
 DB_NAME="${DB_NAME:-asistente_psicologico}"
 DB_USER="${DB_USER:-admin}"
+DB_HOST="${DB_HOST:-localhost}"
 RETENTION_DAYS=90
+
+# PGPASSWORD required for non-interactive auth in cron
+export PGPASSWORD="${DB_PASSWORD:?DB_PASSWORD env var is required}"
 
 # Create backup directory if not exists
 mkdir -p "$BACKUP_DIR"
 
-# Perform backup
-echo "[$(date)] Starting backup..."
-pg_dump -U "$DB_USER" -Fc "$DB_NAME" > "$BACKUP_DIR/${DB_NAME}_${DATE}.dump"
+BACKUP_FILE="$BACKUP_DIR/${DB_NAME}_${DATE}.dump"
 
-# Check if successful
+# pg_dump -Fc produces a compressed custom-format archive — no gzip needed
+echo "[$(date)] Starting backup..."
+pg_dump -U "$DB_USER" -h "$DB_HOST" -Fc "$DB_NAME" > "$BACKUP_FILE"
+
 if [ $? -eq 0 ]; then
     echo "[$(date)] Backup successful: ${DB_NAME}_${DATE}.dump"
-    
-    # Compress
-    gzip "$BACKUP_DIR/${DB_NAME}_${DATE}.dump"
-    echo "[$(date)] Compressed: ${DB_NAME}_${DATE}.dump.gz"
 else
     echo "[$(date)] ERROR: Backup failed!"
+    rm -f "$BACKUP_FILE"
     exit 1
 fi
 
 # Clean old backups
 echo "[$(date)] Cleaning backups older than $RETENTION_DAYS days..."
-find "$BACKUP_DIR" -name "*.dump.gz" -mtime +$RETENTION_DAYS -delete
+find "$BACKUP_DIR" -name "*.dump" -mtime +$RETENTION_DAYS -delete
 
 echo "[$(date)] Done. Total backups: $(ls -1 "$BACKUP_DIR" | wc -l)"

--- a/infrastructure/bot-compose.yml
+++ b/infrastructure/bot-compose.yml
@@ -10,9 +10,16 @@ services:
       - "3000:3000"
     volumes:
       - ./bot/sessions:/app/sessions
-      - ./bot/data.json:/app/data.json:ro
     environment:
       - BOT_NAME=AsistentePsicologico
       - SESSION_PATH=/app/sessions
+      - DATABASE_URL=${DATABASE_URL}
+      - DEFAULT_PSYCHOLOGIST_ID=${DEFAULT_PSYCHOLOGIST_ID}
+      - N8N_WEBHOOK_URL=${N8N_WEBHOOK_URL:-http://n8n:5678/webhook}
     restart: unless-stopped
-    network_mode: host
+    networks:
+      - asistente-network
+
+networks:
+  asistente-network:
+    external: true

--- a/infrastructure/init-db.sql
+++ b/infrastructure/init-db.sql
@@ -335,7 +335,7 @@ CREATE TABLE clinical_impression (
     
     summary TEXT,
     formulation TEXT,
-    Prognosis TEXT,
+    prognosis TEXT,
     recommendations TEXT,
     
     version INT DEFAULT 1,
@@ -451,15 +451,6 @@ CREATE TABLE knowledge_base (
 
 CREATE INDEX idx_knowledge_category ON knowledge_base(category);
 CREATE INDEX idx_knowledge_psychologist ON knowledge_base(psychologist_id);
-
--- Trigger for updated_at
-CREATE OR REPLACE FUNCTION update_updated_at()
-RETURNS TRIGGER AS $$
-BEGIN
-    NEW.updated_at = CURRENT_TIMESTAMP;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
 
 CREATE TRIGGER knowledge_base_updated_at
     BEFORE UPDATE ON knowledge_base


### PR DESCRIPTION
## Resumen

| Issue | Archivo | Fix |
|-------|---------|-----|
| **M-01** | `dashboard/tsconfig.json` | `jsx: react-compiler` → `react-jsx` (valor inválido bloqueaba tsc) |
| **M-06** | `infrastructure/init-db.sql` | Eliminada la segunda definición duplicada de `update_updated_at()` |
| **M-07** | `infrastructure/init-db.sql` | Columna `Prognosis` → `prognosis` (inconsistente con snake_case del resto) |
| **M-09** | `infrastructure/bot-compose.yml` | Agregados `DATABASE_URL` y `DEFAULT_PSYCHOLOGIST_ID`; reemplazado `network_mode: host` por red named `asistente-network` |
| **M-12** | `infrastructure/backups/backup.sh` | Agregado `export PGPASSWORD` — sin esto pg_dump cuelga esperando input en cron |
| **M-13** | `infrastructure/backups/backup.sh` | Eliminado `gzip` redundante — `pg_dump -Fc` ya genera archivo comprimido |

## Plan de prueba

- [x] `tsc --noEmit` en el dashboard pasa sin errores de jsx
- [x] `bash -n backup.sh` → sintaxis válida
- [x] `docker compose -f bot-compose.yml config` → válido, sin network_mode: host
- [x] `psql -f init-db.sql` → sin errores de columna ni función duplicada

https://claude.ai/code/session_01Vho68CtjhxQidvEXV5gQNJ