### PR TITLE
fix(dashboard): credenciales hardcodeadas y password en consola

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,0 +1,10 @@
+# ============================================
+# Asistente Psicológico - Dashboard Environment
+# ============================================
+
+# API base URL (required in production)
+VITE_API_URL=http://localhost:5678/webhook
+
+# Dashboard login credentials (required)
+VITE_DASHBOARD_USER=admin
+VITE_DASHBOARD_PASS=changeme123

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -8,8 +8,12 @@ interface AuthState {
 
 const AuthContext = createContext<AuthState | null>(null)
 
-const AUTH_USER = 'admin'
-const AUTH_PASS = 'password'
+const AUTH_USER = import.meta.env.VITE_DASHBOARD_USER
+const AUTH_PASS = import.meta.env.VITE_DASHBOARD_PASS
+
+if (!AUTH_USER || !AUTH_PASS) {
+  throw new Error('VITE_DASHBOARD_USER and VITE_DASHBOARD_PASS env vars are required')
+}
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(() => {

--- a/dashboard/src/pages/auth/LoginPage.tsx
+++ b/dashboard/src/pages/auth/LoginPage.tsx
@@ -11,12 +11,8 @@ export default function LoginPage() {
     e.preventDefault()
     e.stopPropagation()
     
-    console.log('Attempt login:', user, pass)
-    
     try {
       const ok = login(user, pass)
-      console.log('Login success:', ok)
-      
       if (ok) {
         window.location.href = '/dashboard'
       } else {


### PR DESCRIPTION
## Resumen

### M-02 — Credenciales hardcodeadas en AuthContext.tsx
`AUTH_USER = 'admin'` y `AUTH_PASS = 'password'` estaban literales en el código. Cualquiera con acceso al repositorio o al bundle del frontend conoce las credenciales del panel.

**Fix**: leer desde `import.meta.env.VITE_DASHBOARD_USER` y `VITE_DASHBOARD_PASS` (vars de entorno Vite, embebidas en el build). Fail-fast si alguna falta. Agregado `dashboard/.env.example` con las vars requeridas.

### M-03 — Password logueada en consola del browser
`console.log('Attempt login:', user, pass)` y `console.log('Login success:', ok)` se ejecutaban en cada intento de login — la contraseña quedaba visible en DevTools de cualquier sesión.

**Fix**: eliminados ambos `console.log`.

## Plan de prueba

- [x] Buildear sin `VITE_DASHBOARD_USER` → error en tiempo de carga (no en runtime)
- [x] Buildear con vars correctas → login funciona
- [x] Abrir DevTools → Network/Console → no aparece password en ningún log
- [x] Credenciales incorrectas → mensaje de error en UI, sin logs

https://claude.ai/code/session_01Vho68CtjhxQidvEXV5gQNJ