### PR TITLE
fix(sprint-1): Bugs críticos de producción — FK, auth env vars, nginx proxy, CI/CD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,19 @@
 # Agentes de Asistente Psicológico
 
 ## Stack Principal
+
 - **Backend**: Node.js, PostgreSQL, n8n
 - **Bot**: BuilderBot + WPPConnect
 - **Frontend**: React + Vite + Tailwind CSS 4 + shadcn/ui
 
 ## Ramas
+
 - `main` - Versión estable del MVP
 - `release` - Versionado y pre-lanzamiento
 - `dev` - Desarrollo activo
 
 ## Workflow
+
 1. Crear rama feature desde `dev`
 2. Desarrollar y testear
 3. Mergear a `dev`
@@ -18,6 +21,7 @@
 5. Versionar (tag) → mergear a `main`
 
 ## Comandos
+
 ```bash
 # Nuevo feature
 git checkout dev
@@ -41,12 +45,14 @@ git push origin main
 ```
 
 ## Puertos
+
 - n8n: 5678
 - bot: 3000
 - dashboard: 5173
 - PostgreSQL: 5432
 
 ## Stack de Comandos
+
 ```bash
 # Instalar todo
 cd bot && pnpm install
@@ -61,10 +67,12 @@ cd dashboard && pnpm build  # Production build
 ```
 
 ## Notas Importantes
+
 - El bot de WhatsApp tiene problemas de conexión desde redes restringidas (necesita VPS)
 - Credenciales dashboard: admin / password (cambiar en producción)
 
 ## Documentación
+
 - README.md - Documentación principal (ES/EN)
 - CHANGELOG.md - Historial de cambios
 - infrastructure/README.md - Documentación de n8n

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -20,8 +20,12 @@ const catchAllFlow = addKeyword(['.*'])
 const helpFlow = addKeyword(['ayuda', 'help', '?', 'socorro'])
     .addAnswer('*Opciones disponibles:*\n\n📅 Agendar / Cita\n📋 Mi Historia Clínica\n📚 Biblioteca\n🏠 Menú\n\n*Escribí una opción.*')
 
+const PORT = process.env.PORT || 3000
+const HOST = process.env.HOST || '0.0.0.0'
+
 const main = async () => {
-    console.log('🔄 Iniciando bot...')
+    console.log('🔄 Iniciando bot con Baileys...')
+    console.log('📍 Puerto:', PORT, '| Host:', HOST)
 
     const database = new MemoryDB()
 
@@ -78,9 +82,9 @@ const main = async () => {
     })
 
     const { httpServer } = result
-    httpServer(3000)
+    httpServer(PORT, HOST)
 
-    console.log('✅ Bot listo en http://localhost:3000')
+    console.log(`✅ Bot listo en http://${HOST}:${PORT}`)
     console.log('📱 Esperando mensajes...')
 }
 

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,6 +7,12 @@ COPY package.json pnpm-lock.yaml ./
 RUN corepack enable pnpm && pnpm install --frozen-lockfile
 
 COPY . ./
+
+ARG VITE_AUTH_USER
+ARG VITE_AUTH_PASS
+ENV VITE_AUTH_USER=$VITE_AUTH_USER
+ENV VITE_AUTH_PASS=$VITE_AUTH_PASS
+
 RUN pnpm run build
 
 # Production stage with nginx

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -8,11 +8,11 @@ interface AuthState {
 
 const AuthContext = createContext<AuthState | null>(null)
 
-const AUTH_USER = import.meta.env.VITE_DASHBOARD_USER
-const AUTH_PASS = import.meta.env.VITE_DASHBOARD_PASS
+const AUTH_USER = import.meta.env.VITE_AUTH_USER
+const AUTH_PASS = import.meta.env.VITE_AUTH_PASS
 
 if (!AUTH_USER || !AUTH_PASS) {
-  throw new Error('VITE_DASHBOARD_USER and VITE_DASHBOARD_PASS env vars are required')
+  throw new Error('VITE_AUTH_USER and VITE_AUTH_PASS env vars are required')
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {

--- a/infrastructure/docker-compose.production.yml
+++ b/infrastructure/docker-compose.production.yml
@@ -27,6 +27,7 @@ services:
       - EXECUTIONS_TIMEOUT=300
       - EXECUTIONS_DATA_SAVE_ON_ERROR=all
       - EXECUTIONS_DATA_SAVE_ON_SUCCESS=all
+      - DEFAULT_PSYCHOLOGIST_ID=${PSYCHOLOGIST_ID}
     volumes:
       - n8n_data:/home/node/.n8n
     ports:
@@ -56,12 +57,13 @@ services:
     build:
       context: ../dashboard
       dockerfile: Dockerfile
+      args:
+        - VITE_AUTH_USER=${DASHBOARD_USER}
+        - VITE_AUTH_PASS=${DASHBOARD_PASSWORD}
     container_name: asistente-dashboard
     restart: unless-stopped
     environment:
       - VITE_API_URL=${VITE_API_URL}
-      - VITE_AUTH_USER=${DASHBOARD_USER:-admin}
-      - VITE_AUTH_PASS=${DASHBOARD_PASSWORD}
     ports:
       - "80:80"
       - "443:443"

--- a/infrastructure/n8n/api-create-patient.json
+++ b/infrastructure/n8n/api-create-patient.json
@@ -19,7 +19,7 @@
         "operation": "executeQuery",
         "query": "INSERT INTO patients (psychologist_id, first_name, last_name, email, phone, consent_status, created_at, updated_at)\nVALUES ($1::uuid, $2, $3, $4, $5, 'pending', NOW(), NOW())\nRETURNING id, first_name, last_name, email",
         "options": {
-          "queryReplacement": "={{ $json.body.psychologist_id }},={{ $json.body.first_name }},={{ $json.body.last_name }},={{ $json.body.email }},={{ $json.body.phone }}"
+          "queryReplacement": "={{ $env.DEFAULT_PSYCHOLOGIST_ID }},={{ $json.body.first_name }},={{ $json.body.last_name }},={{ $json.body.email }},={{ $json.body.phone }}"
         }
       },
       "id": "create-patient",


### PR DESCRIPTION
## Resumen / Summary

Corrige los bugs críticos que impedían el uso real del sistema en producción.  
Fixes critical bugs blocking real production usage.

Closes #68

---

## Cambios / Changes

### 🔴 Fix 1 — n8n: `psychologist_id` FK constraint failure
**Archivo**: `infrastructure/n8n/api-create-patient.json`  
**Problema**: El workflow usaba `$json.body.psychologist_id` pero el dashboard nunca enviaba ese campo → FK violation en cada creación de paciente.  
**Fix**: Cambia a `$env.DEFAULT_PSYCHOLOGIST_ID` (variable de entorno del servicio n8n).  
**⚠️ Acción manual requerida en Railway**: agregar `DEFAULT_PSYCHOLOGIST_ID=<uuid>` al servicio n8n.

### 🔴 Fix 2 — Auth: env vars desalineadas entre AuthContext, Dockerfile y docker-compose
**Archivos**: `dashboard/src/contexts/AuthContext.tsx`, `dashboard/Dockerfile`, `infrastructure/docker-compose.production.yml`  
**Problema triple**:
1. `AuthContext` leía `VITE_DASHBOARD_USER/PASS` pero docker-compose seteaba `VITE_AUTH_USER/PASS` → credenciales siempre `undefined`
2. `Dockerfile` no tenía `ARG`/`ENV` → Vite no podía embeber los valores en build time
3. docker-compose no pasaba `build-args` → las vars no llegaban al build  
**Fix**: Unifica en `VITE_AUTH_USER`/`VITE_AUTH_PASS` en todas las capas. Agrega `ARG`+`ENV` en Dockerfile y `args:` en docker-compose.

### ✅ Ya corregido en `dev` (verificado)
- **nginx `/api/` proxy** → inline en `dashboard/Dockerfile` (Sprint anterior)
- **CI/CD `docker-push.yml`** → existe y funciona con secrets `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`
- **Credenciales hardcodeadas** → eliminadas en `dev`, ahora usan `import.meta.env`

---

## Checklist de deploy / Deploy checklist

- [ ] Agregar en Railway — servicio **n8n**: `DEFAULT_PSYCHOLOGIST_ID=<uuid del psicólogo>`
- [ ] Agregar en Railway — servicio **dashboard** (build vars): `DASHBOARD_USER=<user>` y `DASHBOARD_PASSWORD=<pass>`
- [ ] Verificar que existe al menos 1 fila en tabla `psychologists` con el UUID configurado
- [ ] Re-importar `api-create-patient.json` en n8n UI y activar
- [ ] Rebuild imagen dashboard para que Vite embeba las credenciales
- [ ] Smoke test: crear paciente desde dashboard → verificar fila en PostgreSQL con `psychologist_id`

---

## ⚠️ Limitación conocida (Sprint 4)
`VITE_AUTH_USER/PASS` quedan embebidas en el bundle JS — visibles con DevTools.  
Esto es aceptable para MVP pero será reemplazado por JWT en Sprint 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)