### PR TITLE
feat(bot): Sprint 2 — Bot end-to-end booking + session persistence + DB migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ sessions/
 AsistentePsicologico_sessions/
 tokens/
 *.qr.png
+bot/bot_sessions/
+bot/**/*.creds.json
 
 # Database
 *.sql.bak

--- a/bot/.dockerignore
+++ b/bot/.dockerignore
@@ -1,0 +1,6 @@
+node_modules/
+bot_sessions/
+*.creds.json
+*.log
+.env
+.env.*

--- a/bot/src/flows/appointment.js
+++ b/bot/src/flows/appointment.js
@@ -1,13 +1,393 @@
 import { addAnswer, addKeyword } from '@builderbot/bot'
-import { appointmentService, DURATIONS } from '../services/appointmentService.js'
+import {
+    appointmentService,
+    DURATIONS,
+    getNextAvailableDates,
+    getAvailableSlots,
+    createAppointmentBot,
+    getUpcomingAppointmentsByEmail,
+    cancelAppointmentBot
+} from '../services/appointmentService.js'
 
-const appointmentFlow = addKeyword(['agendar', 'cita', 'turno', 'reservar'])
-    .addAnswer('📅 *Agendar Cita*\n\nHorario de atención:\n• Martes a Domingo\n• 09:00 a 18:00\n• Lunch: 12:00 a 13:00\n\n*Duración:*\n• Primera vez: 90 min\n• Seguimiento: 50 min\n\n*¿Qué tipo de consulta necesitas?*', {
-        buttons: [
-            { body: '👤 Primera vez' },
-            { body: '🔄 Seguimiento' }
-        ]
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers / Funciones auxiliares
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parses a DD/MM/YYYY string and validates that it is a future weekday.
+ * Analiza un string DD/MM/YYYY y valida que sea un día hábil futuro.
+ *
+ * @param {string} raw - Raw user input / Texto ingresado por el usuario
+ * @returns {{ ok: true, isoDate: string } | { ok: false, reason: string }}
+ */
+function parseDDMMYYYY(raw) {
+    const trimmed = (raw || '').trim()
+    if (!/^\d{2}\/\d{2}\/\d{4}$/.test(trimmed)) {
+        return { ok: false, reason: 'formato' }
+    }
+    const [dd, mm, yyyy] = trimmed.split('/').map(Number)
+    const date = new Date(yyyy, mm - 1, dd)
+    // Validate calendar (e.g. 31/02 would shift) / Validar calendario
+    if (date.getFullYear() !== yyyy || date.getMonth() + 1 !== mm || date.getDate() !== dd) {
+        return { ok: false, reason: 'formato' }
+    }
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    if (date <= today) {
+        return { ok: false, reason: 'pasado' }
+    }
+    const dow = date.getDay()
+    if (dow === 0 || dow === 6) {
+        return { ok: false, reason: 'finde' }
+    }
+    const mmStr = String(mm).padStart(2, '0')
+    const ddStr = String(dd).padStart(2, '0')
+    return { ok: true, isoDate: `${yyyy}-${mmStr}-${ddStr}` }
+}
+
+/**
+ * Formats a Date (or ISO string from DB) as "DD/MM/YYYY HH:MM".
+ * Formatea una Date (o ISO string de DB) como "DD/MM/YYYY HH:MM".
+ *
+ * @param {Date|string} dt
+ * @returns {string}
+ */
+function formatDateTime(dt) {
+    const d = dt instanceof Date ? dt : new Date(dt)
+    const dd = String(d.getDate()).padStart(2, '0')
+    const mm = String(d.getMonth() + 1).padStart(2, '0')
+    const yyyy = d.getFullYear()
+    const hh = String(d.getHours()).padStart(2, '0')
+    const min = String(d.getMinutes()).padStart(2, '0')
+    return `${dd}/${mm}/${yyyy} ${hh}:${min}`
+}
+
+/**
+ * Formats a Date (or ISO string) as "DD/MM/YYYY".
+ * Formatea una Date (o ISO string) como "DD/MM/YYYY".
+ *
+ * @param {Date|string} dt
+ * @returns {string}
+ */
+function formatDate(dt) {
+    const d = dt instanceof Date ? dt : new Date(dt)
+    const dd = String(d.getDate()).padStart(2, '0')
+    const mm = String(d.getMonth() + 1).padStart(2, '0')
+    return `${dd}/${mm}/${d.getFullYear()}`
+}
+
+/**
+ * Builds a human-readable numbered slot list split into Morning / Afternoon.
+ * Construye una lista numerada de slots legible dividida en Mañana / Tarde.
+ *
+ * @param {Array<{label: string, value: string}>} slots
+ * @returns {string}
+ */
+function buildSlotListText(slots) {
+    const morning = slots.filter(s => {
+        const h = parseInt(s.label.split(':')[0], 10)
+        return h < 12
     })
+    const afternoon = slots.filter(s => {
+        const h = parseInt(s.label.split(':')[0], 10)
+        return h >= 13
+    })
+
+    let text = ''
+    if (morning.length > 0) {
+        text += '*Mañana:*\n'
+        morning.forEach((s, i) => { text += `  ${i + 1}. ${s.label}\n` })
+    }
+    if (afternoon.length > 0) {
+        const offset = morning.length
+        text += '*Tarde:*\n'
+        afternoon.forEach((s, i) => { text += `  ${offset + i + 1}. ${s.label}\n` })
+    }
+    return text.trim()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 2: Appointment Booking Flow / Flujo de reserva de turno
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Main booking flow — triggered by booking keywords.
+ * Flujo principal de reserva — disparado por palabras clave de reserva.
+ *
+ * Steps:
+ *   1. Show 7 weekday date buttons + "Otra fecha"
+ *   2. Show available slots for selected date
+ *   2b. "Otra fecha" branch: capture + validate DD/MM/YYYY
+ *   3. Confirmation summary (no DB write)
+ *   4. Confirm → createAppointmentBot() | Cancel → exit
+ */
+export const appointmentFlow = addKeyword(['agendar', 'cita', 'turno', 'reservar'])
+    .addAnswer(
+        '📅 *Reservar Turno*\n\n¿Cuál es tu email?',
+        { capture: true },
+        async (ctx, { state }) => {
+            await state.update({ email: ctx.body.trim(), step: 'email' })
+            console.log(`[appointmentFlow] step=email_captured phone=${ctx.from?.slice(-4)}`)
+        }
+    )
+    .addAnswer(
+        '¿Cuál es tu nombre completo?',
+        { capture: true },
+        async (ctx, { state }) => {
+            await state.update({ fullName: ctx.body.trim() })
+        }
+    )
+    .addAnswer(
+        '*¿Qué fecha preferís?*\n\nElegí un número o escribí *otra* para ingresar una fecha manualmente:',
+        { capture: true },
+        async (ctx, { state, flowDynamic }) => {
+            // Build and show date list / Mostrar lista de fechas
+            const dates = getNextAvailableDates(7)
+            let dateMenu = ''
+            dates.forEach((d, i) => { dateMenu += `  ${i + 1}. ${d.label}\n` })
+            dateMenu += `  8. Otra fecha (DD/MM/YYYY)`
+
+            await flowDynamic(dateMenu)
+            await state.update({ _availableDates: dates, step: 'date_menu' })
+            console.log(`[appointmentFlow] step=date_menu_shown phone=${ctx.from?.slice(-4)}`)
+        }
+    )
+    .addAnswer(
+        'Seleccioná el número de la fecha o escribí la fecha en formato *DD/MM/YYYY*:',
+        { capture: true },
+        async (ctx, { state, flowDynamic }) => {
+            const input = ctx.body.trim()
+            const stateData = await state.getAll()
+            const dates = stateData._availableDates || []
+
+            let chosenISO = null
+            let chosenLabel = null
+
+            // Numeric choice from the menu / Elección numérica del menú
+            const num = parseInt(input, 10)
+            if (!isNaN(num) && num >= 1 && num <= dates.length) {
+                const picked = dates[num - 1]
+                chosenISO = picked.value
+                chosenLabel = picked.label
+            } else if (!isNaN(num) && num === dates.length + 1) {
+                // "Otra fecha" option / Opción "Otra fecha"
+                await state.update({ step: 'custom_date' })
+                await flowDynamic('Ingresá la fecha en formato *DD/MM/YYYY* (ej: 15/05/2026):')
+                return
+            } else if (/^\d{2}\/\d{2}\/\d{4}$/.test(input)) {
+                // Direct DD/MM/YYYY entry / Ingreso directo DD/MM/YYYY
+                const parsed = parseDDMMYYYY(input)
+                if (!parsed.ok) {
+                    const msgs = {
+                        pasado: '❌ Esa fecha ya pasó. Ingresá una fecha futura.',
+                        finde: '❌ Los fines de semana no hay atención. Ingresá un día de semana.',
+                        formato: '❌ Formato inválido. Usá *DD/MM/YYYY* (ej: 15/05/2026).'
+                    }
+                    await flowDynamic(msgs[parsed.reason] || msgs.formato)
+                    await state.update({ _error: true })
+                    return
+                }
+                chosenISO = parsed.isoDate
+                const [yyyy, mm, dd] = chosenISO.split('-')
+                chosenLabel = `${dd}/${mm}/${yyyy}`
+            } else {
+                await flowDynamic('❌ Opción inválida. Ingresá un número de la lista o una fecha en formato *DD/MM/YYYY*.')
+                await state.update({ _error: true })
+                return
+            }
+
+            // Fetch slots / Obtener slots
+            const psychologistId = process.env.DEFAULT_PSYCHOLOGIST_ID
+            const slots = await getAvailableSlots(chosenISO, psychologistId)
+            console.log(`[appointmentFlow] step=date_selected phone=${ctx.from?.slice(-4)} date=${chosenISO} slots=${slots.length}`)
+
+            if (slots.length === 0) {
+                await flowDynamic(`No hay horarios disponibles para el ${chosenLabel}. Probá con otro día.\n\nEscribí *agendar* para volver a empezar.`)
+                await state.clear()
+                return
+            }
+
+            const slotText = buildSlotListText(slots)
+            await flowDynamic(`*Horarios disponibles para ${chosenLabel}:*\n\n${slotText}\n\nElegí el número del horario:`)
+            await state.update({
+                chosenDate: chosenISO,
+                chosenDateLabel: chosenLabel,
+                _slots: slots,
+                step: 'slot_menu'
+            })
+        }
+    )
+    .addAnswer(
+        'Número de horario:',
+        { capture: true },
+        async (ctx, { state, flowDynamic }) => {
+            const stateData = await state.getAll()
+
+            if (stateData._error) {
+                await state.clear()
+                return
+            }
+
+            // Handle custom date branch / Manejar rama de fecha personalizada
+            if (stateData.step === 'custom_date') {
+                const parsed = parseDDMMYYYY(ctx.body.trim())
+                if (!parsed.ok) {
+                    const msgs = {
+                        pasado: '❌ Esa fecha ya pasó. Ingresá una fecha futura.',
+                        finde: '❌ Los fines de semana no hay atención. Ingresá un día de semana.',
+                        formato: '❌ Formato inválido. Usá *DD/MM/YYYY* (ej: 15/05/2026).'
+                    }
+                    await flowDynamic(msgs[parsed.reason] || msgs.formato)
+                    await flowDynamic('Escribí *agendar* para reiniciar.')
+                    await state.clear()
+                    return
+                }
+
+                const psychologistId = process.env.DEFAULT_PSYCHOLOGIST_ID
+                const slots = await getAvailableSlots(parsed.isoDate, psychologistId)
+                const [yyyy, mm, dd] = parsed.isoDate.split('-')
+                const label = `${dd}/${mm}/${yyyy}`
+
+                console.log(`[appointmentFlow] step=custom_date_resolved phone=${ctx.from?.slice(-4)} date=${parsed.isoDate} slots=${slots.length}`)
+
+                if (slots.length === 0) {
+                    await flowDynamic(`No hay horarios disponibles para el ${label}. Probá con otro día.\n\nEscribí *agendar* para volver a empezar.`)
+                    await state.clear()
+                    return
+                }
+
+                const slotText = buildSlotListText(slots)
+                await flowDynamic(`*Horarios disponibles para ${label}:*\n\n${slotText}\n\nElegí el número del horario:`)
+                await state.update({
+                    chosenDate: parsed.isoDate,
+                    chosenDateLabel: label,
+                    _slots: slots,
+                    step: 'slot_menu'
+                })
+                return
+            }
+
+            // Slot selection / Selección de slot
+            const slots = stateData._slots || []
+            const num = parseInt(ctx.body.trim(), 10)
+            if (isNaN(num) || num < 1 || num > slots.length) {
+                await flowDynamic(`❌ Elegí un número entre 1 y ${slots.length}.`)
+                await state.update({ _error: true })
+                return
+            }
+
+            const chosenSlot = slots[num - 1]
+            console.log(`[appointmentFlow] step=slot_selected phone=${ctx.from?.slice(-4)} slot=${chosenSlot.label}`)
+
+            await state.update({ chosenSlot, step: 'confirm' })
+            await flowDynamic(
+                `📋 *Resumen del turno:*\n\n` +
+                `• Fecha: ${stateData.chosenDateLabel}\n` +
+                `• Hora: ${chosenSlot.label}\n` +
+                `• Nombre: ${stateData.fullName}\n` +
+                `• Email: ${stateData.email}\n\n` +
+                `Respondé *1* para Confirmar o *2* para Cancelar.`
+            )
+        }
+    )
+    .addAnswer(
+        '¿Confirmás? (1 = Confirmar / 2 = Cancelar):',
+        { capture: true },
+        async (ctx, { state, flowDynamic }) => {
+            const stateData = await state.getAll()
+
+            if (stateData._error || stateData.step !== 'confirm') {
+                await state.clear()
+                return
+            }
+
+            const answer = ctx.body.trim()
+
+            if (answer === '2' || answer.toLowerCase().includes('cancel')) {
+                console.log(`[appointmentFlow] step=user_cancelled phone=${ctx.from?.slice(-4)}`)
+                await flowDynamic('Está bien, no se realizó ningún cambio. Escribí *menu* para volver al inicio.')
+                await state.clear()
+                return
+            }
+
+            if (answer !== '1' && !answer.toLowerCase().includes('confirm')) {
+                await flowDynamic('Respondé *1* para Confirmar o *2* para Cancelar.')
+                return
+            }
+
+            // ── DB write / Escritura en DB ────────────────────────────────────
+            const psychologistId = process.env.DEFAULT_PSYCHOLOGIST_ID
+            const slot = stateData.chosenSlot
+
+            // Calculate end time (30 min slot) / Calcular hora de fin (slot de 30 min)
+            const startDt = new Date(slot.value)
+            const endDt = new Date(startDt.getTime() + 30 * 60 * 1000)
+
+            // Find or create patient / Buscar o crear paciente
+            let patientId = null
+            try {
+                let patient = await appointmentService.findPatientByEmail(stateData.email)
+                if (!patient) {
+                    patient = await appointmentService.createPatient({
+                        fullName: stateData.fullName,
+                        email: stateData.email,
+                        phone: ctx.from,
+                        psychologistId
+                    })
+                }
+                patientId = patient.id
+            } catch (err) {
+                console.error('[appointmentFlow] patient lookup/create error:', err.message)
+                await flowDynamic('❌ Hubo un error. Por favor intentá de nuevo o contactanos.')
+                await state.clear()
+                return
+            }
+
+            console.log(`[appointmentFlow] step=insert_attempt phone=${ctx.from?.slice(-4)} date=${stateData.chosenDate} slot=${slot.label}`)
+
+            const result = await createAppointmentBot({
+                patientId,
+                psychologistId,
+                startTime: startDt.toISOString(),
+                endTime: endDt.toISOString()
+            })
+
+            if (result.ok) {
+                console.log(`[appointmentFlow] step=insert_ok id=${result.id} phone=${ctx.from?.slice(-4)}`)
+                await flowDynamic(
+                    `✅ Turno confirmado para el ${stateData.chosenDateLabel} a las ${slot.label}.\n` +
+                    `Te enviaremos un recordatorio.\n\nEscribí *menu* para volver al inicio.`
+                )
+                await state.clear()
+                return
+            }
+
+            if (result.reason === 'slot_taken') {
+                console.warn(`[appointmentFlow] step=insert_conflict phone=${ctx.from?.slice(-4)} reason=slot_taken`)
+                // Re-query and re-present slots / Re-consultar y re-mostrar slots
+                const freshSlots = await getAvailableSlots(stateData.chosenDate, psychologistId)
+                if (freshSlots.length === 0) {
+                    await flowDynamic(`⚠️ Ese horario se ocupó y ya no hay más disponibles para el ${stateData.chosenDateLabel}.\n\nEscribí *agendar* para elegir otro día.`)
+                    await state.clear()
+                    return
+                }
+                const slotText = buildSlotListText(freshSlots)
+                await flowDynamic(`⚠️ Ese horario se ocupó. Elegí otro:\n\n${slotText}`)
+                await state.update({ _slots: freshSlots, step: 'slot_menu' })
+                return
+            }
+
+            // db_error / error de base de datos
+            console.error(`[appointmentFlow] step=db_error phone=${ctx.from?.slice(-4)}`)
+            await flowDynamic('❌ Hubo un error. Por favor intentá de nuevo o contactanos.')
+            await state.clear()
+        }
+    )
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Existing flows (unchanged — regression boundary)
+// Flows existentes (sin cambios — límite de regresión)
+// ─────────────────────────────────────────────────────────────────────────────
 
 export const primeraVezFlow = addKeyword(['primera vez', '👤 Primera vez'])
     .addAnswer(
@@ -205,6 +585,8 @@ export const seguimientoFlow = addKeyword(['seguimiento', '🔄 Seguimiento'])
         await state.clear()
     })
 
+// appointmentStatusFlow is a regression boundary — DO NOT MODIFY.
+// appointmentStatusFlow es un límite de regresión — NO MODIFICAR.
 export const appointmentStatusFlow = addKeyword(['mis citas', 'ver cita', 'mi cita', 'citas'])
     .addAnswer('📅 *Tus Citas*\n\n*Escribí tu email:*', { capture: true }, async (ctx, { flowDynamic }) => {
         const email = ctx.body.trim()
@@ -241,38 +623,158 @@ export const appointmentStatusFlow = addKeyword(['mis citas', 'ver cita', 'mi ci
         })
     })
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 3: Cancellation Flow / Flujo de cancelación de turno
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Cancellation flow — triggered by "cancelar" keywords.
+ * Flujo de cancelación — disparado por palabras clave de cancelar.
+ *
+ * Steps:
+ *   1. Ask for email
+ *   2. Query upcoming appointments (0→exit, 1→direct confirm, 2-5→numbered list)
+ *   3. 2-hour cutoff check
+ *   4. Confirm → cancelAppointmentBot() | Decline → exit
+ */
 export const cancelAppointmentFlow = addKeyword(['cancelar cita', 'cancelar', 'reagendar'])
-    .addAnswer('📅 *Cancelar Cita*\n\nEscribí tu email de registro:', { capture: true }, async (ctx, { flowDynamic }) => {
-        const email = ctx.body.trim()
-        const patient = await appointmentService.findPatientByEmail(email)
-
-        if (!patient) {
-            await flowDynamic('📭 No encontré un paciente con ese email.\n\nEscribí *menu*.')
-            return
+    .addAnswer(
+        '📅 *Cancelar Turno*\n\nEscribí tu email de registro:',
+        { capture: true },
+        async (ctx, { state }) => {
+            await state.update({ email: ctx.body.trim().toLowerCase() })
+            console.log(`[cancelFlow] step=email_captured phone=${ctx.from?.slice(-4)}`)
         }
+    )
+    .addAnswer(
+        'Buscando tus turnos...',
+        { capture: false },
+        async (ctx, { state, flowDynamic }) => {
+            const stateData = await state.getAll()
+            const email = stateData.email
 
-        const appointments = await appointmentService.getPatientAppointments(patient.id)
+            const appointments = await getUpcomingAppointmentsByEmail(email)
+            console.log(`[cancelFlow] step=lookup_done phone=${ctx.from?.slice(-4)} email_local=${email.split('@')[0]} count=${appointments.length}`)
 
-        if (!appointments || appointments.length === 0) {
-            await flowDynamic('📭 No tenés citas programadas para cancelar.\n\nEscribí *menu*.')
-            return
+            if (appointments.length === 0) {
+                await flowDynamic('No tenés turnos próximos pendientes.\n\nEscribí *menu* para volver al inicio.')
+                await state.clear()
+                return
+            }
+
+            await state.update({ _appointments: appointments })
+
+            if (appointments.length === 1) {
+                // Single appointment — show details and ask directly
+                // Un solo turno — mostrar detalles y preguntar directamente
+                const appt = appointments[0]
+                const dtStr = formatDateTime(appt.start_time)
+                await flowDynamic(
+                    `Tenés este turno próximo:\n\n` +
+                    `📅 ${dtStr} — ${appt.type || 'Consulta'}\n\n` +
+                    `¿Querés cancelarlo? Respondé *1* para Sí o *2* para No.`
+                )
+                await state.update({ selectedApptId: appt.id, selectedApptStart: appt.start_time, step: 'confirm_cancel' })
+            } else {
+                // Multiple appointments — show numbered list
+                // Múltiples turnos — mostrar lista numerada
+                let listText = 'Tus próximos turnos:\n\n'
+                appointments.forEach((appt, i) => {
+                    listText += `  ${i + 1}. ${formatDateTime(appt.start_time)} — ${appt.type || 'Consulta'}\n`
+                })
+                listText += '\nElegí el número del turno que querés cancelar:'
+                await flowDynamic(listText)
+                await state.update({ step: 'select_appt' })
+            }
         }
+    )
+    .addAnswer(
+        'Tu elección:',
+        { capture: true },
+        async (ctx, { state, flowDynamic }) => {
+            const stateData = await state.getAll()
 
-        const next = appointments[0]
-        const cancelled = await appointmentService.cancelAppointment(next.id, patient.id)
+            if (!stateData.step) {
+                await state.clear()
+                return
+            }
 
-        if (!cancelled) {
-            await flowDynamic('❌ No se pudo cancelar la cita. Contactanos directamente.')
-            return
+            // ── Selection step (multiple appointments) ────────────────────────
+            if (stateData.step === 'select_appt') {
+                const appointments = stateData._appointments || []
+                const num = parseInt(ctx.body.trim(), 10)
+                if (isNaN(num) || num < 1 || num > appointments.length) {
+                    await flowDynamic(`❌ Elegí un número entre 1 y ${appointments.length}.`)
+                    await state.update({ _error: true })
+                    return
+                }
+                const picked = appointments[num - 1]
+                await state.update({
+                    selectedApptId: picked.id,
+                    selectedApptStart: picked.start_time,
+                    step: 'confirm_cancel'
+                })
+                const dtStr = formatDateTime(picked.start_time)
+                await flowDynamic(
+                    `Vas a cancelar el turno del *${dtStr}*.\n\n` +
+                    `Respondé *1* para Confirmar o *2* para No cancelar.`
+                )
+                return
+            }
+
+            // ── Confirmation step ─────────────────────────────────────────────
+            if (stateData.step === 'confirm_cancel') {
+                const answer = ctx.body.trim()
+
+                if (answer === '2' || answer.toLowerCase().includes('no')) {
+                    console.log(`[cancelFlow] step=user_declined phone=${ctx.from?.slice(-4)}`)
+                    await flowDynamic('Está bien, el turno no fue cancelado.\n\nEscribí *menu* para volver al inicio.')
+                    await state.clear()
+                    return
+                }
+
+                if (answer !== '1' && !answer.toLowerCase().includes('si') && !answer.toLowerCase().includes('sí')) {
+                    await flowDynamic('Respondé *1* para Confirmar o *2* para No cancelar.')
+                    return
+                }
+
+                // 2-hour cutoff check / Verificación de corte de 2 horas
+                const startTime = new Date(stateData.selectedApptStart)
+                const twoHoursFromNow = new Date(Date.now() + 2 * 60 * 60 * 1000)
+                if (startTime <= twoHoursFromNow) {
+                    console.warn(`[cancelFlow] step=cutoff_blocked phone=${ctx.from?.slice(-4)}`)
+                    await flowDynamic('No podés cancelar con menos de 2 horas de anticipación.\n\nSi necesitás ayuda, contactanos directamente.\n\nEscribí *menu* para volver al inicio.')
+                    await state.clear()
+                    return
+                }
+
+                // Proceed with cancellation / Proceder con la cancelación
+                console.log(`[cancelFlow] step=cancel_attempt phone=${ctx.from?.slice(-4)} id=${stateData.selectedApptId}`)
+                const result = await cancelAppointmentBot(stateData.selectedApptId)
+
+                if (result.ok) {
+                    const dtStr = formatDateTime(stateData.selectedApptStart)
+                    console.log(`[cancelFlow] step=cancel_ok phone=${ctx.from?.slice(-4)} id=${stateData.selectedApptId}`)
+                    await flowDynamic(`✅ Tu turno del *${dtStr}* fue cancelado exitosamente.\n\nEscribí *menu* para volver al inicio.`)
+                    await state.clear()
+                    return
+                }
+
+                if (result.reason === 'already_cancelled') {
+                    console.warn(`[cancelFlow] step=already_cancelled phone=${ctx.from?.slice(-4)}`)
+                    await flowDynamic('Ese turno ya estaba cancelado.\n\nEscribí *menu* para volver al inicio.')
+                    await state.clear()
+                    return
+                }
+
+                // db_error
+                console.error(`[cancelFlow] step=db_error phone=${ctx.from?.slice(-4)}`)
+                await flowDynamic('❌ Hubo un error al cancelar. Por favor intentá de nuevo o contactanos.\n\nEscribí *menu* para volver al inicio.')
+                await state.clear()
+                return
+            }
+
+            // Unknown state — reset / Estado desconocido — reiniciar
+            await state.clear()
         }
-
-        const date = new Date(next.scheduled_at)
-        const dateStr = date.toLocaleDateString('es-MX', {
-            weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
-        })
-        await flowDynamic(
-            `✅ *Cita cancelada:*\n\n📅 ${dateStr}\n⏰ ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}\n\n⚠️ Recordá avisar con 24h de anticipación.\n\nEscribí *menu*.`
-        )
-    })
-
-export { appointmentFlow }
+    )

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -1,7 +1,15 @@
 import 'dotenv/config'
+import { mkdirSync } from 'fs'
 import { createBot, createProvider, createFlow, addKeyword, MemoryDB } from '@builderbot/bot'
 import pkg from '@builderbot/provider-wppconnect'
 const { WPPConnectProvider } = pkg
+
+// ── Session persistence / Persistencia de sesión ──────────────────────────
+// BOT_SESSION_PATH is the directory where WPPConnect stores its session tokens.
+// BOT_SESSION_PATH es el directorio donde WPPConnect guarda los tokens de sesión.
+// Railway mounts a volume at /app/bot_sessions; local dev defaults to ./bot_sessions.
+const AUTH_PATH = process.env.BOT_SESSION_PATH || '/app/bot_sessions'
+mkdirSync(AUTH_PATH, { recursive: true })
 
 import { mainMenuFlow } from './flows/mainMenu.js'
 import { appointmentFlow, primeraVezFlow, seguimientoFlow, appointmentStatusFlow, cancelAppointmentFlow } from './flows/appointment.js'
@@ -24,20 +32,40 @@ const PORT = process.env.PORT || 3000
 const HOST = process.env.HOST || '0.0.0.0'
 
 const main = async () => {
-    console.log('🔄 Iniciando bot con Baileys...')
+    console.log('🔄 Iniciando bot con WPPConnect...')
     console.log('📍 Puerto:', PORT, '| Host:', HOST)
+    console.log(`📂 Session path: ${AUTH_PATH}`)
+    console.log('⚠️  NOTA: el estado de conversación (MemoryDB) es volátil — un reinicio del proceso resetea las conversaciones en curso.')
 
     const database = new MemoryDB()
 
-    const provider = createProvider(WPPConnectProvider, {
-        name: 'AsistentePsicologico',
-        qr: false,
-        folderNameToken: 'tokens',
-        puppeteer: {
-            headless: true,
-            args: ['--no-sandbox', '--disable-setuid-sandbox']
-        }
-    })
+    // folderNameToken points WPPConnect at the session directory persisted via Railway volume.
+    // folderNameToken apunta WPPConnect al directorio de sesión persistido via Railway volume.
+    let provider
+    try {
+        provider = createProvider(WPPConnectProvider, {
+            name: 'AsistentePsicologico',
+            qr: false,
+            folderNameToken: AUTH_PATH,
+            puppeteer: {
+                headless: true,
+                args: ['--no-sandbox', '--disable-setuid-sandbox']
+            }
+        })
+    } catch (err) {
+        // Auth load failure — log loudly and allow bot to regenerate QR on next connection attempt.
+        // Fallo al cargar auth — loguear y permitir que el bot regenere QR en el próximo intento.
+        console.error('ERROR [index] wppconnect_auth_failed — regenerating session:', err.message)
+        provider = createProvider(WPPConnectProvider, {
+            name: 'AsistentePsicologico',
+            qr: true,
+            folderNameToken: AUTH_PATH,
+            puppeteer: {
+                headless: true,
+                args: ['--no-sandbox', '--disable-setuid-sandbox']
+            }
+        })
+    }
 
     provider.parser?.on?.('message', (msg) => {
         console.log('📨 [PARSER]', msg.body)

--- a/bot/src/services/appointmentService.js
+++ b/bot/src/services/appointmentService.js
@@ -10,6 +10,50 @@ const pool = new Pool({
     connectionString: process.env.DATABASE_URL
 })
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Slot grid constants / Constantes de la grilla de horarios
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** First bookable hour of the day / Primera hora reservable del día */
+const SLOT_START_HOUR = 9
+
+/** Last slot start hour (17:30 → ends 18:00) / Última hora de inicio de slot */
+const SLOT_END_HOUR_LAST_START = 17
+const SLOT_END_MINUTE_LAST_START = 30
+
+/** Slot duration in minutes / Duración de cada slot en minutos */
+const SLOT_INTERVAL_MINUTES = 30
+
+/** Lunch window start / Inicio de la ventana de almuerzo */
+const LUNCH_START_HOUR = 12
+
+/** Lunch window end (exclusive) / Fin de la ventana de almuerzo (exclusivo) */
+const LUNCH_END_HOUR = 13
+
+/** Max slots returned per query / Máximo de slots devueltos por consulta */
+const SLOT_MAX_RESULTS = 12
+
+/** Weekday numbers (0=Sun, 1=Mon … 6=Sat) that are working days.
+ *  Días de la semana (0=Dom … 6=Sáb) que son hábiles. */
+const WORKING_WEEKDAYS = new Set([1, 2, 3, 4, 5]) // Mon–Fri
+
+/** Max upcoming appointments returned for cancellation / Máximo de turnos próximos para cancelación */
+const CANCEL_LOOKUP_LIMIT = 5
+
+/**
+ * Day-of-week name labels in Spanish (short).
+ * Etiquetas cortas de día de la semana en español.
+ * @type {string[]}
+ */
+const DAY_LABELS_ES = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb']
+
+/**
+ * Month labels in Spanish (short).
+ * Etiquetas cortas de mes en español.
+ * @type {string[]}
+ */
+const MONTH_LABELS_ES = ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
+
 export const BUSINESS_HOURS = {
     start: 9,
     end: 18,
@@ -204,5 +248,196 @@ export const appointmentService = {
         }
 
         return { valid: true, scheduledAt }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sprint 2 — Booking / Cancellation service functions
+// Sprint 2 — Funciones de servicio para reserva / cancelación
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the next N upcoming weekday dates starting from tomorrow.
+ * Retorna los próximos N días hábiles comenzando desde mañana.
+ *
+ * @param {number} [limit=7] - Number of dates to return / Cantidad de fechas a devolver
+ * @returns {Array<{label: string, value: string}>}
+ *   label: human-readable "Lun 27/04" | value: ISO date "2026-04-27"
+ */
+export function getNextAvailableDates(limit = 7) {
+    const results = []
+    const cursor = new Date()
+    cursor.setHours(0, 0, 0, 0)
+    cursor.setDate(cursor.getDate() + 1) // start from tomorrow / empezar desde mañana
+
+    while (results.length < limit) {
+        const dow = cursor.getDay()
+        if (WORKING_WEEKDAYS.has(dow)) {
+            const dayLabel = DAY_LABELS_ES[dow]
+            const dd = String(cursor.getDate()).padStart(2, '0')
+            const mm = String(cursor.getMonth() + 1).padStart(2, '0')
+            const yyyy = cursor.getFullYear()
+
+            results.push({
+                label: `${dayLabel} ${dd}/${mm}`,
+                value: `${yyyy}-${mm}-${dd}`
+            })
+        }
+        cursor.setDate(cursor.getDate() + 1)
+    }
+
+    return results
+}
+
+/**
+ * Returns available 30-minute slots for a given date, excluding booked
+ * (non-cancelled) slots and the lunch window (12:00–12:59).
+ * Uses a single PostgreSQL generate_series query — no app-side filtering.
+ *
+ * Retorna los slots de 30 minutos disponibles para una fecha dada,
+ * excluyendo turnos reservados (no cancelados) y el horario de almuerzo.
+ * Usa una sola consulta generate_series — sin filtrado del lado del app.
+ *
+ * @param {string} dateISO - Date in "YYYY-MM-DD" format / Fecha en formato "YYYY-MM-DD"
+ * @param {string} psychologistId - UUID of the psychologist / UUID del psicólogo
+ * @returns {Promise<Array<{label: string, value: string}>>}
+ *   label: "09:00" | value: ISO timestamp "2026-04-27T09:00:00"
+ */
+export async function getAvailableSlots(dateISO, psychologistId) {
+    const client = await pool.connect()
+    try {
+        const result = await client.query(
+            `WITH slot_grid AS (
+                SELECT generate_series(
+                    ($1::date + TIME '${SLOT_START_HOUR}:00'),
+                    ($1::date + TIME '${SLOT_END_HOUR_LAST_START}:${String(SLOT_END_MINUTE_LAST_START).padStart(2, '0')}'),
+                    INTERVAL '${SLOT_INTERVAL_MINUTES} minutes'
+                ) AS slot
+            ),
+            booked AS (
+                SELECT date_trunc('minute', start_time) AS slot
+                FROM appointments
+                WHERE start_time::date = $1::date
+                  AND psychologist_id = $2
+                  AND status <> 'cancelled'
+            )
+            SELECT slot
+            FROM slot_grid
+            WHERE slot NOT IN (SELECT slot FROM booked)
+              AND EXTRACT(HOUR FROM slot) NOT BETWEEN $3 AND $4 - 1
+            ORDER BY slot
+            LIMIT ${SLOT_MAX_RESULTS}`,
+            [dateISO, psychologistId, LUNCH_START_HOUR, LUNCH_END_HOUR]
+        )
+
+        return result.rows.map(row => {
+            const dt = new Date(row.slot)
+            const hh = String(dt.getUTCHours()).padStart(2, '0')
+            const min = String(dt.getUTCMinutes()).padStart(2, '0')
+            const isoVal = row.slot instanceof Date
+                ? row.slot.toISOString().replace('Z', '')
+                : String(row.slot)
+            return {
+                label: `${hh}:${min}`,
+                value: isoVal
+            }
+        })
+    } catch (err) {
+        console.error('[appointmentService] getAvailableSlots error:', err.message)
+        return []
+    } finally {
+        client.release()
+    }
+}
+
+/**
+ * Creates a new appointment in PostgreSQL with status 'pending' and
+ * created_via 'whatsapp'. Returns a result object — never throws.
+ *
+ * Crea un nuevo turno en PostgreSQL con status 'pending' y
+ * created_via 'whatsapp'. Devuelve un objeto resultado — nunca lanza.
+ *
+ * @param {{ patientId: string, psychologistId: string, startTime: string, endTime: string }} data
+ * @returns {Promise<{ok: true, id: string} | {ok: false, reason: 'slot_taken'|'db_error'}>}
+ */
+export async function createAppointmentBot({ patientId, psychologistId, startTime, endTime }) {
+    const client = await pool.connect()
+    try {
+        const result = await client.query(
+            `INSERT INTO appointments
+               (patient_id, psychologist_id, start_time, end_time, status, created_via, created_at)
+             VALUES ($1, $2, $3, $4, 'pending', 'whatsapp', NOW())
+             RETURNING id`,
+            [patientId, psychologistId, startTime, endTime]
+        )
+        return { ok: true, id: result.rows[0].id }
+    } catch (err) {
+        // PostgreSQL error code 23505 = unique_violation / código 23505 = violación de unicidad
+        if (err.code === '23505') {
+            return { ok: false, reason: 'slot_taken' }
+        }
+        console.error('[appointmentService] createAppointmentBot error:', err.message)
+        return { ok: false, reason: 'db_error' }
+    } finally {
+        client.release()
+    }
+}
+
+/**
+ * Returns upcoming non-cancelled appointments for a patient identified by email.
+ * Max 5 results ordered by start_time ascending.
+ *
+ * Retorna los turnos próximos no cancelados de un paciente identificado por email.
+ * Máximo 5 resultados ordenados por start_time ascendente.
+ *
+ * @param {string} email - Patient email / Email del paciente
+ * @returns {Promise<Array<{id: string, start_time: Date, type: string, status: string}>>}
+ */
+export async function getUpcomingAppointmentsByEmail(email) {
+    try {
+        const result = await pool.query(
+            `SELECT id, start_time, appointment_type AS type, status
+             FROM appointments
+             WHERE patient_email = $1
+               AND start_time >= NOW()
+               AND status <> 'cancelled'
+             ORDER BY start_time ASC
+             LIMIT ${CANCEL_LOOKUP_LIMIT}`,
+            [email.toLowerCase().trim()]
+        )
+        return result.rows
+    } catch (err) {
+        console.error('[appointmentService] getUpcomingAppointmentsByEmail error:', err.message)
+        return []
+    }
+}
+
+/**
+ * Soft-cancels an appointment by ID. Sets status='cancelled' and updated_at=NOW().
+ * Returns a result object — never throws.
+ *
+ * Cancela suavemente un turno por ID. Establece status='cancelled' y updated_at=NOW().
+ * Devuelve un objeto resultado — nunca lanza.
+ *
+ * @param {string} id - Appointment UUID / UUID del turno
+ * @returns {Promise<{ok: true} | {ok: false, reason: 'already_cancelled'|'db_error'}>}
+ */
+export async function cancelAppointmentBot(id) {
+    try {
+        const result = await pool.query(
+            `UPDATE appointments
+             SET status = 'cancelled', updated_at = NOW()
+             WHERE id = $1 AND status <> 'cancelled'
+             RETURNING id`,
+            [id]
+        )
+        if (result.rows.length === 0) {
+            // No rows updated → appointment was already cancelled / Ya estaba cancelado
+            return { ok: false, reason: 'already_cancelled' }
+        }
+        return { ok: true }
+    } catch (err) {
+        console.error('[appointmentService] cancelAppointmentBot error:', err.message)
+        return { ok: false, reason: 'db_error' }
     }
 }

--- a/infrastructure/docker-compose.production.yml
+++ b/infrastructure/docker-compose.production.yml
@@ -45,8 +45,10 @@ services:
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - DEFAULT_PSYCHOLOGIST_ID=${PSYCHOLOGIST_ID}
+      - BOT_SESSION_PATH=/app/bot_sessions
     volumes:
       - ./tokens:/app/tokens
+      - bot_sessions:/app/bot_sessions
     networks:
       - asistente-network
     depends_on:
@@ -74,6 +76,8 @@ services:
 
 volumes:
   n8n_data:
+  bot_sessions:
+    driver: local
 
 networks:
   asistente-network:

--- a/infrastructure/migrations/001_appointment_unique_slot.sql
+++ b/infrastructure/migrations/001_appointment_unique_slot.sql
@@ -1,0 +1,11 @@
+-- Migration: 001_appointment_unique_slot
+-- Prevents double-booking the same slot for the same psychologist.
+-- Previene la doble reserva del mismo horario para el mismo psicólogo.
+--
+-- The partial index only covers non-cancelled appointments, so a cancelled
+-- slot can be re-booked by a different (or the same) patient.
+-- El índice parcial solo cubre turnos no cancelados, permitiendo reutilizar slots cancelados.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_appointments_no_double_booking
+  ON appointments (psychologist_id, start_time)
+  WHERE status <> 'cancelled';

--- a/infrastructure/migrations/002_patient_email_index.sql
+++ b/infrastructure/migrations/002_patient_email_index.sql
@@ -1,0 +1,10 @@
+-- Migration: 002_patient_email_index
+-- Speeds up cancellation flow email lookup.
+-- Acelera la búsqueda por email en el flujo de cancelación.
+--
+-- Without this index, every cancellation request performs a full table scan
+-- on appointments. With ~thousands of rows this becomes noticeably slow.
+-- Sin este índice, cada cancelación hace un full table scan.
+
+CREATE INDEX IF NOT EXISTS idx_appointments_patient_email
+  ON appointments (patient_email);

--- a/infrastructure/migrations/003_appointments_updated_at.sql
+++ b/infrastructure/migrations/003_appointments_updated_at.sql
@@ -1,0 +1,8 @@
+-- Migration: 003_appointments_updated_at
+-- Adds updated_at column required for soft-cancel timestamp.
+-- Agrega la columna updated_at requerida para la marca de tiempo de cancelación suave.
+--
+-- Uses ADD COLUMN IF NOT EXISTS so the migration is idempotent and safe to re-run.
+-- Usa IF NOT EXISTS para que la migración sea idempotente y segura de re-ejecutar.
+
+ALTER TABLE appointments ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;


### PR DESCRIPTION
## Summary

- **appointmentFlow**: flujo completo de reserva por WhatsApp (email → nombre → fecha con botones → slot → confirmación → `createAppointmentBot`)
- **cancelAppointmentFlow**: cancelación suave con validación de corte de 2 horas antes del turno
- **appointmentService**: 5 nuevas funciones — `getNextAvailableDates`, `getAvailableSlots` (PostgreSQL `generate_series`), `createAppointmentBot` (guarda con `status='pending'`, `created_via='whatsapp'`), `getUpcomingAppointmentsByEmail`, `cancelAppointmentBot`
- **index.js**: `BOT_SESSION_PATH` + `mkdirSync` para persistencia de sesión en Railway volume
- **docker-compose**: named volume `bot_sessions` + env var `BOT_SESSION_PATH`
- **migrations/001**: índice UNIQUE parcial `WHERE status <> 'cancelled'` — previene double-booking
- **migrations/002**: índice en `patient_email` para búsqueda rápida en cancelación
- **migrations/003**: columna `updated_at` en `appointments` para timestamp de soft-cancel
- **.gitignore / .dockerignore**: excluye `bot_sessions/` y `*.creds.json`

## Test plan

- [ ] Ejecutar las 3 migraciones en la DB de Railway antes de deployar
- [ ] Verificar que `BOT_SESSION_PATH=/app/bot_sessions` esté configurado en Railway (bot service)
- [ ] Probar flujo completo de reserva por WhatsApp
- [ ] Probar flujo de cancelación con más de 2 horas de anticipación
- [ ] Probar cancelación con menos de 2 horas (debe rechazar)
- [ ] Verificar que tras reinicio del bot la sesión de WPPConnect persiste (no pide QR)

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)