### PR TITLE
fix(p2): config, env vars, status filter, PG pool, DAYS consistency

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -5,8 +5,11 @@
 # PostgreSQL (required)
 DATABASE_URL=postgresql://user:password@host:5432/asistente_psicologico
 
-# Psychologist (required)
+# Psychologist (required) — UUID of the default psychologist for all bot appointments
 DEFAULT_PSYCHOLOGIST_ID=00000000-0000-0000-0000-000000000000
+
+# JWT secret — must match the value in n8n service (required)
+JWT_SECRET=change-this-to-a-secure-random-string
 
 # n8n Webhook (required)
 N8N_WEBHOOK_URL=https://your-n8n.up.railway.app/webhook
@@ -14,10 +17,18 @@ N8N_WEBHOOK_URL=https://your-n8n.up.railway.app/webhook
 # Bot ports (optional — Railway sets PORT automatically)
 PORT=3001
 BOT_API_PORT=3000
+HOST=0.0.0.0
 BOT_SESSION_PATH=/app/bot_sessions
 
-# WhatsApp pairing — set ONLY for first boot, remove after session is saved
+# WhatsApp — pairing mode (set only for first boot, unset after session is saved)
 # WA_PHONE_NUMBER=5491112345678
+
+# WhatsApp — session restore from base64-encoded creds.json (Railway volume backup)
+# Export with: base64 -w0 ~/.../creds.json
+# WA_CREDS_B64=
+
+# WhatsApp — force wipe session and re-pair (set to true + WA_CREDS_B64 to restore a backup)
+# WA_FORCE_RESET=false
 
 # OpenAI (for knowledge base feature)
 # OPENAI_API_KEY=sk-...

--- a/bot/src/services/appointmentService.js
+++ b/bot/src/services/appointmentService.js
@@ -60,7 +60,7 @@ export const DURATIONS = {
     seguimiento: 50
 }
 
-export const DAYS = [2, 3, 4, 5, 6, 0]
+export const DAYS = [...WORKING_WEEKDAYS]
 
 export function createAppointmentService(db) {
     return {
@@ -329,7 +329,13 @@ let _pool = null
 function _getPool() {
     if (!_pool) {
         if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL environment variable is required')
-        _pool = new Pool({ connectionString: process.env.DATABASE_URL })
+        _pool = new Pool({
+            connectionString: process.env.DATABASE_URL,
+            ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+            max: 5,
+            idleTimeoutMillis: 30000,
+            connectionTimeoutMillis: 5000,
+        })
     }
     return _pool
 }

--- a/bot/src/services/knowledgeBase.js
+++ b/bot/src/services/knowledgeBase.js
@@ -54,7 +54,13 @@ let _pool = null
 function _getPool() {
     if (!_pool) {
         if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL environment variable is required')
-        _pool = new Pool({ connectionString: process.env.DATABASE_URL })
+        _pool = new Pool({
+            connectionString: process.env.DATABASE_URL,
+            ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+            max: 3,
+            idleTimeoutMillis: 30000,
+            connectionTimeoutMillis: 5000,
+        })
     }
     return _pool
 }

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -2,8 +2,9 @@
 # Asistente Psicológico - Dashboard Environment
 # ============================================
 
-# API base URL (required in production)
-VITE_API_URL=http://localhost:5678/webhook
+# API base URL — use /api in production (proxied by nginx to n8n webhook)
+# For local dev pointing directly to n8n: http://localhost:5678/webhook
+VITE_API_URL=/api
 
 # WhatsApp number for CTA button (international format, no + or spaces)
 VITE_WHATSAPP_NUMBER=521234567890
@@ -15,6 +16,6 @@ VITE_CLINIC_ADDRESS=Calle 123 # 45-67, Bogotá, Colombia
 VITE_CLINIC_PHONE=+57 300 123 4567
 VITE_CLINIC_EMAIL=contacto@consultorio.example.com
 
-# Dashboard login credentials (required)
-VITE_DASHBOARD_USER=admin
-VITE_DASHBOARD_PASS=changeme123
+# Dashboard login credentials (required — must match build-time ARGs in Dockerfile)
+VITE_AUTH_USER=admin
+VITE_AUTH_PASS=changeme123

--- a/dashboard/src/pages/dashboard/DashboardPage.tsx
+++ b/dashboard/src/pages/dashboard/DashboardPage.tsx
@@ -15,7 +15,7 @@ async function fetchStats() {
 }
 
 async function fetchUpcoming() {
-  return api.get('/appointments?status=scheduled&status=confirmed&limit=5&page=1')
+  return api.get('/appointments?status=scheduled,confirmed&limit=5&page=1')
 }
 
 function StatCard({ title, value, description, icon: Icon, iconBg = 'bg-primary/10', iconColor = 'text-primary' }: {

--- a/infrastructure/migrations/001_appointment_unique_slot.sql
+++ b/infrastructure/migrations/001_appointment_unique_slot.sql
@@ -7,5 +7,5 @@
 -- El índice parcial solo cubre turnos no cancelados, permitiendo reutilizar slots cancelados.
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_appointments_no_double_booking
-  ON appointments (psychologist_id, start_time)
+  ON appointments (psychologist_id, scheduled_at)
   WHERE status <> 'cancelled';

--- a/infrastructure/n8n/api-appointments.json
+++ b/infrastructure/n8n/api-appointments.json
@@ -25,7 +25,7 @@
     },
     {
       "parameters": {
-        "jsCode": "const q = $input.item.json.query || {};\nconst page = Math.max(1, parseInt(q.page || '1', 10));\nconst limit = Math.min(100, Math.max(1, parseInt(q.limit || '20', 10)));\nconst status = q.status || null;\n$input.item.json.pg_limit = limit;\n$input.item.json.pg_offset = (page - 1) * limit;\n$input.item.json.pg_page = page;\n$input.item.json.pg_status = status;\nreturn $input.item;",
+        "jsCode": "const q = $input.item.json.query || {};\nconst page = Math.max(1, parseInt(q.page || '1', 10));\nconst limit = Math.min(100, Math.max(1, parseInt(q.limit || '20', 10)));\nconst rawStatus = Array.isArray(q.status) ? q.status.join(',') : (q.status || null);\n$input.item.json.pg_limit = limit;\n$input.item.json.pg_offset = (page - 1) * limit;\n$input.item.json.pg_page = page;\n$input.item.json.pg_status = rawStatus;\nreturn $input.item;",
         "options": {}
       },
       "id": "pagination", "name": "Code - Pagination Params", "type": "n8n-nodes-base.code", "typeVersion": 2, "position": [1000, 150]
@@ -33,7 +33,7 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "SELECT\n  a.id,\n  a.scheduled_at AT TIME ZONE COALESCE(ps.timezone, 'America/Mexico_City') AS scheduled_at,\n  a.duration_minutes,\n  a.appointment_type,\n  a.status,\n  a.session_notes,\n  a.google_meet_link,\n  p.id AS patient_id,\n  p.first_name,\n  p.last_name,\n  p.email,\n  p.phone,\n  ps.full_name AS psychologist_name,\n  COUNT(*) OVER() AS total_count\nFROM appointments a\nJOIN patients p ON p.id = a.patient_id\nJOIN psychologists ps ON ps.id = a.psychologist_id\nWHERE a.deleted_at IS NULL\n  AND ($3::text IS NULL OR a.status = $3::text)\nORDER BY a.scheduled_at ASC\nLIMIT $1 OFFSET $2",
+        "query": "SELECT\n  a.id,\n  a.scheduled_at AT TIME ZONE COALESCE(ps.timezone, 'America/Mexico_City') AS scheduled_at,\n  a.duration_minutes,\n  a.appointment_type,\n  a.status,\n  a.session_notes,\n  a.google_meet_link,\n  p.id AS patient_id,\n  p.first_name,\n  p.last_name,\n  p.email,\n  p.phone,\n  ps.full_name AS psychologist_name,\n  COUNT(*) OVER() AS total_count\nFROM appointments a\nJOIN patients p ON p.id = a.patient_id\nJOIN psychologists ps ON ps.id = a.psychologist_id\nWHERE a.deleted_at IS NULL\n  AND ($3::text IS NULL OR a.status = ANY(string_to_array($3, ',')))\nORDER BY a.scheduled_at ASC\nLIMIT $1 OFFSET $2",
         "options": { "queryReplacement": "={{ $json.pg_limit }},={{ $json.pg_offset }},={{ $json.pg_status }}" }
       },
       "id": "postgres", "name": "PostgreSQL", "type": "n8n-nodes-base.postgres", "typeVersion": 2.4, "position": [1250, 150]


### PR DESCRIPTION
## Summary

- **Migration 001**: `start_time` → `scheduled_at` en el índice único anti double-booking — falla en entornos limpios sin migration 007 (Closes #79)
- **`.env.example` dashboard**: `VITE_DASHBOARD_USER/PASS` → `VITE_AUTH_USER/PASS` para que coincida con `AuthContext.tsx`; `VITE_API_URL` apunta a `/api` en lugar de n8n directo (Closes #83)
- **`.env.example` bot**: agrega `WA_CREDS_B64`, `WA_FORCE_RESET`, `HOST`, `JWT_SECRET` — todas usadas en el código pero sin documentar
- **`DashboardPage.tsx`**: fix URL del widget upcoming: `?status=scheduled&status=confirmed` → `?status=scheduled,confirmed` — n8n solo procesaba el primero (Closes #84)
- **`api-appointments.json`**: soporte multi-status via `ANY(string_to_array($3, ','))` — aplicado en producción vía API n8n (Closes #84)
- **`appointmentService.js`**: `DAYS = [...WORKING_WEEKDAYS]` — una sola fuente de verdad para días laborables (Closes #86); PG Pool con SSL, max:5, timeouts (Closes #85)
- **`knowledgeBase.js`**: PG Pool con misma configuración SSL/límites (Closes #85)

## Cambios en producción (ya aplicados via n8n API)
- `api-appointments.json`: status filter actualizado con `ANY(string_to_array)` — activo en live
- Verificado: `GET /api/appointments?status=scheduled,confirmed` devuelve ambos statuses ✅

## Test plan
- [x] Login en dashboard con las nuevas vars de `.env.example` funciona
- [x] Widget "Próximas citas" en `/dashboard` muestra citas `scheduled` Y `confirmed`
- [x] `GET /api/appointments?status=scheduled,confirmed` devuelve ambos statuses
- [x] `GET /api/appointments?status=completed` filtra correctamente por status único
- [x] Bot: agendamiento de cita usa `WORKING_WEEKDAYS` — días consistentes en disponibilidad y validación
- [x] Migration 001 aplicable en entorno limpio sin error de columna

🤖 Generated with [Claude Code](https://claude.com/claude-code)