### PR TITLE
feat(sprint-7a): infra — migration 008 + nginx rate limiting

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -31,9 +31,7 @@ FROM nginx:alpine
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-RUN rm /etc/nginx/conf.d/default.conf
-
-COPY nginx.conf.template /etc/nginx/conf.d/app.conf.template
+COPY nginx.conf.template /etc/nginx/nginx.conf.template
 
 # Default for local docker-compose; override in Railway with:
 # N8N_INTERNAL_URL=http://n8n.railway.internal:5678
@@ -44,4 +42,4 @@ EXPOSE 80
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost/health || exit 1
 
-CMD ["/bin/sh", "-c", "envsubst '${N8N_INTERNAL_URL}' < /etc/nginx/conf.d/app.conf.template > /etc/nginx/conf.d/app.conf && nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", "envsubst '${N8N_INTERNAL_URL}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"]

--- a/dashboard/nginx.conf.template
+++ b/dashboard/nginx.conf.template
@@ -1,36 +1,75 @@
-server {
-    listen 80;
-    server_name localhost;
-    root /usr/share/nginx/html;
-    index index.html;
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    keepalive_timeout 65;
 
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
     gzip_min_length 1000;
 
-    location = /health {
-        return 200 "ok\n";
-        add_header Content-Type text/plain;
-        access_log off;
-    }
+    # Rate limiting zones
+    # General API traffic: 10 req/s per IP, burst 20
+    limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
+    # Auth endpoint: 5 req/min per IP (≈1 req/12s), burst 5 — throttles credential stuffing
+    limit_req_zone $binary_remote_addr zone=auth:10m rate=5r/m;
 
-    location /api/ {
-        rewrite ^/api/(.*) /webhook/$1 break;
-        proxy_pass ${N8N_INTERNAL_URL};
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 60s;
-    }
+    server {
+        listen 80;
+        server_name localhost;
+        root /usr/share/nginx/html;
+        index index.html;
 
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
+        location = /health {
+            return 200 "ok\n";
+            add_header Content-Type text/plain;
+            access_log off;
+        }
 
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
+        # Auth route — more specific, must come BEFORE /api/ block.
+        # Aggressive rate limit to block brute-force login attempts.
+        location /api/auth/ {
+            limit_req        zone=auth burst=5 nodelay;
+            limit_req_status 429;
+
+            rewrite ^/api/(.*) /webhook/$1 break;
+            proxy_pass         ${N8N_INTERNAL_URL};
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_read_timeout 60s;
+        }
+
+        # General API traffic — looser limit for normal dashboard use.
+        location /api/ {
+            limit_req        zone=api burst=20 nodelay;
+            limit_req_status 429;
+
+            rewrite ^/api/(.*) /webhook/$1 break;
+            proxy_pass         ${N8N_INTERNAL_URL};
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_read_timeout 60s;
+        }
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
     }
 }

--- a/infrastructure/migrations/008_add_psychologist_role_active.sql
+++ b/infrastructure/migrations/008_add_psychologist_role_active.sql
@@ -1,0 +1,11 @@
+-- Migration 008: Add role and is_active columns to psychologists
+-- Idempotent: safe to re-run (uses IF NOT EXISTS guards).
+-- NOTE: was planned as 007 in Sprint 7a spec, but 007 was already taken by
+--       007_fix_appointment_unique_index. Renumbered to 008.
+
+ALTER TABLE psychologists
+  ADD COLUMN IF NOT EXISTS role      VARCHAR(20) NOT NULL DEFAULT 'psychologist',
+  ADD COLUMN IF NOT EXISTS is_active BOOLEAN     NOT NULL DEFAULT TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_psychologists_role
+  ON psychologists(role);


### PR DESCRIPTION
## Summary

- Add `infrastructure/migrations/008_add_psychologist_role_active.sql`: idempotent migration that adds `role VARCHAR(20) DEFAULT 'psychologist'` and `is_active BOOLEAN DEFAULT TRUE` columns to `psychologists` table, plus `idx_psychologists_role` index.
- Restructure `dashboard/nginx.conf.template` as a full `nginx.conf` (with `events {}` and `http {}` context) to support `limit_req_zone` directives at the correct scope.
- Add two rate-limiting zones: `api` (10 r/s, burst 20) and `auth` (5 r/m, burst 5), with `limit_req_status 429`.
- Add `/api/auth/` location block (more specific, matched first) with aggressive auth rate limit.
- Update Dockerfile to mount the template as `/etc/nginx/nginx.conf` instead of a `conf.d` snippet.

## Notes

- Migration was planned as 007 in Sprint 7a spec but renumbered to 008 because `007_fix_appointment_unique_index.sql` already existed.
- This PR is infra-only (no JWT changes). Safe to merge independently before PR 2.

## Test plan

- [ ] Run `node infrastructure/migrate.js` — verify `008` is applied and recorded in `schema_migrations`
- [ ] Re-run migrate.js — confirm migration is skipped (idempotent)
- [ ] Build Docker image locally — confirm nginx starts without errors
- [ ] Send >5 login requests within 1 minute from same IP — verify 429 after burst
- [ ] Send >20 simultaneous `/api/` requests — verify 429 beyond burst threshold