### PR TITLE
feat(sprint-7b/3): backup verify + railway health check

### DIFF
--- a/infrastructure/backups/backup.sh
+++ b/infrastructure/backups/backup.sh
@@ -32,6 +32,15 @@ else
     exit 1
 fi
 
+# Verify backup integrity (structural check via TOC parse — no DB required)
+pg_restore --list "$BACKUP_FILE" > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "[$(date)] ERROR: Restore-verify failed for $BACKUP_FILE" >&2
+    exit 1
+fi
+echo "OK   $BACKUP_FILE   $(stat -c%s "$BACKUP_FILE")bytes   $(date)" >> "$(dirname "$0")/backup.log"
+echo "[$(date)] Backup verified: TOC parsed successfully"
+
 # Clean old backups
 echo "[$(date)] Cleaning backups older than $RETENTION_DAYS days..."
 find "$BACKUP_DIR" -name "*.dump" -mtime +$RETENTION_DAYS -delete

--- a/infrastructure/monitoring/railway-health-check.sh
+++ b/infrastructure/monitoring/railway-health-check.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Health check poller for Railway deployment
+# Polls $RAILWAY_PUBLIC_URL/health every INTERVAL seconds.
+# Sends webhook alert to $ALERT_WEBHOOK_URL on MAX_FAILS consecutive failures.
+# Exits gracefully if RAILWAY_PUBLIC_URL is not set.
+
+: "${RAILWAY_PUBLIC_URL:=}"
+if [ -z "$RAILWAY_PUBLIC_URL" ]; then
+  echo "RAILWAY_PUBLIC_URL not set, exiting"
+  exit 0
+fi
+
+FAIL_COUNT=0
+MAX_FAILS="${MAX_FAILS:-3}"
+INTERVAL="${INTERVAL:-60}"
+ALERT_WEBHOOK_URL="${ALERT_WEBHOOK_URL:-}"
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) Health check started: ${RAILWAY_PUBLIC_URL}/health (interval=${INTERVAL}s, max_fails=${MAX_FAILS})"
+
+while true; do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${RAILWAY_PUBLIC_URL}/health" --max-time 10 2>/dev/null || echo "000")
+
+  if [[ "$STATUS" =~ ^2 ]]; then
+    if [ "$FAIL_COUNT" -gt 0 ]; then
+      echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) Health check recovered (HTTP $STATUS)"
+    fi
+    FAIL_COUNT=0
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) Health check failed ($FAIL_COUNT/$MAX_FAILS): HTTP $STATUS"
+
+    if [ "$FAIL_COUNT" -ge "$MAX_FAILS" ]; then
+      echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) Sending alert to webhook..."
+      if [ -n "$ALERT_WEBHOOK_URL" ]; then
+        curl -s -X POST "$ALERT_WEBHOOK_URL" \
+          -H "Content-Type: application/json" \
+          -d "{\"text\":\"ALERT: ${RAILWAY_PUBLIC_URL}/health failed ${MAX_FAILS} times consecutively (last HTTP status: ${STATUS})\"}" \
+          --max-time 10 || true
+      else
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) WARNING: ALERT_WEBHOOK_URL not set, skipping notification" >&2
+      fi
+      FAIL_COUNT=0
+    fi
+  fi
+
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary

- Updates `infrastructure/backups/backup.sh`: adds `pg_restore --list` restore-verify step after successful dump. Exits 1 and writes to stderr on corrupt/truncated archive; appends a success line to `backup.log` on pass. PGPASSWORD and -Fc (no gzip) were already correct — only the verify step was added.
- Adds `infrastructure/monitoring/railway-health-check.sh`: bash polling script that hits `$RAILWAY_PUBLIC_URL/health` every 60s, counts consecutive failures, and fires an HTTP POST to `$ALERT_WEBHOOK_URL` after 3 consecutive failures. Exits 0 immediately when `RAILWAY_PUBLIC_URL` is unset. Supports `MAX_FAILS` and `INTERVAL` env var overrides.

## Test plan

- [ ] Run backup.sh with a valid DB → verify `backup.log` gets a success line
- [ ] Create a truncated .dump file, run verify step manually → confirm exit 1 + stderr message
- [ ] Run health check with RAILWAY_PUBLIC_URL unset → confirm immediate exit 0
- [ ] Set RAILWAY_PUBLIC_URL to an unreachable endpoint, set MAX_FAILS=3 → confirm webhook fires after 3rd failure
- [ ] Set RAILWAY_PUBLIC_URL to a healthy endpoint → confirm no webhook fires

## Notes

- `ALERT_WEBHOOK_URL` must be set in Railway env vars for alert delivery. Documented in infrastructure/.env.template.