### PR TITLE
fix(security): bump fast-uri >=3.1.2 — Dependabot #4 #5

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -28,7 +28,8 @@
     "overrides": {
       "protobufjs": ">=6.11.4",
       "got": ">=11.8.3",
-      "file-type": ">=22.0.1"
+      "file-type": ">=22.0.1",
+      "fast-uri": ">=3.1.2"
     },
     "patchedDependencies": {
       "@builderbot/provider-baileys": "patches/@builderbot__provider-baileys.patch"

--- a/bot/pnpm-lock.yaml
+++ b/bot/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   protobufjs: '>=6.11.4'
   got: '>=11.8.3'
   file-type: '>=22.0.1'
+  fast-uri: '>=3.1.2'
 
 patchedDependencies:
   '@builderbot/provider-baileys':
@@ -874,8 +875,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   file-type@22.0.1:
     resolution: {integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==}
@@ -2293,7 +2294,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2610,7 +2611,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   file-type@22.0.1:
     dependencies:


### PR DESCRIPTION
## Security Fix + CI Fix

### 1. fast-uri bump (Dependabot #4 #5)

| Alert | Descripción | Afectado | Fix |
|-------|-------------|----------|-----|
| #4 | Path traversal via percent-encoded dot segments | `fast-uri <= 3.1.0` | `3.1.2` |
| #5 | Host confusion via percent-encoded authority delimiters | `fast-uri <= 3.1.1` | `3.1.2` |

Cadena: `ajv@8.18.0` → `fast-uri@3.1.0` → forzado a `fast-uri@3.1.2` via `pnpm.overrides`.

### 2. CI fix — bot Dockerfile (bug regresión)

**Causa raíz:** `corepack enable pnpm` sin campo `packageManager` descargaba pnpm v11.0.9. pnpm v11 requiere Node.js v22.13+, pero el Dockerfile usa `node:20-alpine` (v20.20.2).

**Fix:** reemplazar `corepack enable pnpm` por `npm install -g pnpm@10` — mismo patrón del dashboard Dockerfile. Se agrega `"packageManager": "pnpm@10.32.1"` en `package.json` para consistencia local.

```diff
- RUN corepack enable pnpm && pnpm install --frozen-lockfile --ignore-scripts
+ RUN npm install -g pnpm@10 && pnpm install --frozen-lockfile --ignore-scripts
```

### Archivos cambiados
- `bot/package.json` — `pnpm.overrides.fast-uri: ">=3.1.2"` + `packageManager: "pnpm@10.32.1"`
- `bot/pnpm-lock.yaml` — fast-uri actualizado de 3.1.0 → 3.1.2
- `bot/Dockerfile` — corepack → npm install -g pnpm@10

### Review budget: 14 / 400 ✅

Closes #118