### PR TITLE
fix(ci): replace corepack with npm install -g pnpm@10 in bot Dockerfile

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 COPY patches/ ./patches/
-RUN corepack enable pnpm && pnpm install --frozen-lockfile --ignore-scripts
+RUN npm install -g pnpm@10 && pnpm install --frozen-lockfile --ignore-scripts
 
 COPY . ./
 

--- a/bot/package.json
+++ b/bot/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "WhatsApp Bot para Asistente Psicológico",
   "type": "module",
+  "packageManager": "pnpm@10.32.1",
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",


### PR DESCRIPTION
## Problema

CI fallando con `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` después de mergear el fix de fast-uri (#119).

**Causa raíz:** `corepack enable pnpm` sin `packageManager` field descarga pnpm v11.0.9 (última versión). pnpm v11 requiere `Node.js >= v22.13`, pero el Dockerfile usa `node:20-alpine` (v20.20.2).

```
warn: This version of pnpm requires at least Node.js v22.13
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

## Fix

```diff
- RUN corepack enable pnpm && pnpm install --frozen-lockfile --ignore-scripts
+ RUN npm install -g pnpm@10 && pnpm install --frozen-lockfile --ignore-scripts
```

Mismo patrón que ya usa el dashboard Dockerfile correctamente. Se agrega `"packageManager": "pnpm@10.32.1"` en `package.json` para consistencia local.

## Archivos cambiados

| Archivo | Cambio |
|---------|--------|
| `bot/Dockerfile` | `corepack enable pnpm` → `npm install -g pnpm@10` |
| `bot/package.json` | Agrega `"packageManager": "pnpm@10.32.1"` |

## Review budget: 4 / 400 ✅

Closes #118