### PR TITLE
feat(sprint-w21-p2): RAGService + ingestPdfs + knowledgeBase RAG-first search

### DIFF
--- a/bot/src/__tests__/services/ragService.test.cjs
+++ b/bot/src/__tests__/services/ragService.test.cjs
@@ -172,4 +172,67 @@ describe('ragService.ingest', () => {
         assert.ok(mockAI.embedCallCount > 0, 'embed must be called for each chunk')
         assert.ok(mockDB.queryCallCount > 0, 'DB must be queried for each embedded chunk')
     })
+
+    test('ON CONFLICT (duplicate chunk) increments skipped, not inserted', async () => {
+        const { createRAGService } = await import('../../services/ragService.js')
+        const mockAI = makeMockAIService()
+        const mockDB = {
+            async query(sql) {
+                if (sql.trim().toUpperCase().startsWith('INSERT')) {
+                    return { rows: [], rowCount: 0 } // ON CONFLICT DO NOTHING → rowCount 0
+                }
+                return { rows: [], rowCount: 0 }
+            },
+        }
+        const fakeText = Array(400).fill('palabra').join(' ')
+        const svc = createRAGService({
+            db: mockDB,
+            aiService: mockAI,
+            _readFile: async () => Buffer.from('dummy'),
+            _pdfParse: async () => ({ text: fakeText }),
+        })
+
+        const result = await svc.ingest({ filePath: '/fake/libro.pdf', category: 'test' })
+
+        assert.equal(result.inserted, 0, 'Nothing should be inserted on full conflict')
+        assert.ok(result.skipped > 0, 'All chunks should be counted as skipped')
+    })
+
+    test('embed failure for a chunk increments skipped and continues', async () => {
+        const { createRAGService } = await import('../../services/ragService.js')
+        let callCount = 0
+        const mockAI = {
+            embedCallCount: 0,
+            async embed() {
+                this.embedCallCount++
+                // Fail every other chunk
+                return callCount++ % 2 === 0 ? [] : new Array(1536).fill(0.1)
+            },
+            async complete() { return '' },
+        }
+        const mockDB = {
+            insertCount: 0,
+            async query(sql) {
+                if (sql.trim().toUpperCase().startsWith('INSERT')) {
+                    this.insertCount++
+                    return { rows: [], rowCount: 1 }
+                }
+                return { rows: [], rowCount: 0 }
+            },
+        }
+        // Enough words for at least 2 chunks (375 words per chunk)
+        const fakeText = Array(800).fill('palabra').join(' ')
+        const svc = createRAGService({
+            db: mockDB,
+            aiService: mockAI,
+            _readFile: async () => Buffer.from('dummy'),
+            _pdfParse: async () => ({ text: fakeText }),
+        })
+
+        const result = await svc.ingest({ filePath: '/fake/libro.pdf', category: 'test' })
+
+        assert.ok(result.skipped > 0, 'Failed embed chunks must be counted as skipped')
+        assert.ok(result.inserted > 0, 'Successful embed chunks must still be inserted')
+        assert.equal(result.inserted + result.skipped, mockAI.embedCallCount, 'Total chunks = inserted + skipped')
+    })
 })

--- a/bot/src/__tests__/services/ragService.test.cjs
+++ b/bot/src/__tests__/services/ragService.test.cjs
@@ -1,0 +1,175 @@
+'use strict'
+
+const { test, describe } = require('node:test')
+const assert = require('node:assert/strict')
+
+// ── Mock factories ────────────────────────────────────────────────────────────
+
+/**
+ * Builds a mock AI service with controlled embed/complete responses.
+ *
+ * @param {{ embedResponse?: number[], chatResponse?: string }} opts
+ * @returns {object} Mock AI service compatible with createRAGService DI.
+ */
+function makeMockAIService({ embedResponse, chatResponse } = {}) {
+    return {
+        embedCallCount: 0,
+        async embed(text) {
+            this.embedCallCount++
+            return embedResponse ?? new Array(1536).fill(0.1)
+        },
+        async complete(opts) {
+            return chatResponse ?? 'Respuesta informativa de prueba.'
+        },
+        async completeJSON(opts) {
+            return {}
+        },
+    }
+}
+
+/**
+ * Builds a mock DB that returns a fixed set of rows for any query.
+ *
+ * @param {Array<{chunk_text: string, source_path: string, distance: number}>} rows
+ * @returns {object} Mock DB with a query() method.
+ */
+function makeMockDB(rows = []) {
+    return {
+        queryCallCount: 0,
+        async query(sql, params) {
+            this.queryCallCount++
+            // Simulate rowCount for INSERT statements
+            if (sql.trim().toUpperCase().startsWith('INSERT')) {
+                return { rows: [], rowCount: 1 }
+            }
+            return { rows, rowCount: rows.length }
+        },
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ragService.answer', () => {
+    test('personalisation query returns redirect message — never calls embed', async () => {
+        const { createRAGService } = await import('../../services/ragService.js')
+        const mockAI = makeMockAIService()
+        const mockDB = makeMockDB()
+        const svc = createRAGService({ db: mockDB, aiService: mockAI })
+
+        const result = await svc.answer('creo que sufro de ansiedad')
+
+        assert.ok(result !== null, 'Should return an object, not null')
+        assert.ok(typeof result.answer === 'string', 'answer must be a string')
+        assert.ok(result.answer.includes('profesional'), 'Should contain redirect to professional')
+        assert.deepEqual(result.sources, [], 'sources should be empty array')
+        assert.equal(mockAI.embedCallCount, 0, 'embed must NOT be called for personalisation queries')
+    })
+
+    test('general query with matching chunks returns {answer, sources}', async () => {
+        const { createRAGService } = await import('../../services/ragService.js')
+        const mockAI = makeMockAIService({ chatResponse: 'La ansiedad es una respuesta normal al estrés.' })
+        const mockDB = makeMockDB([
+            { chunk_text: 'La ansiedad es una respuesta adaptativa.', source_path: '/Libros/Ansiedad/libro.pdf', distance: 0.10 },
+            { chunk_text: 'El estrés crónico puede intensificar la ansiedad.', source_path: '/Libros/Ansiedad/libro.pdf', distance: 0.18 },
+        ])
+        const svc = createRAGService({ db: mockDB, aiService: mockAI })
+
+        const result = await svc.answer('qué es la ansiedad')
+
+        assert.ok(result !== null, 'Should return a result when chunks match')
+        assert.equal(typeof result.answer, 'string')
+        assert.ok(result.answer.length > 0)
+        assert.ok(Array.isArray(result.sources))
+        assert.ok(result.sources.length > 0, 'sources should contain distinct paths')
+        assert.equal(result.sources[0], '/Libros/Ansiedad/libro.pdf')
+    })
+
+    test('embed returns [] (API error) → returns null', async () => {
+        const { createRAGService } = await import('../../services/ragService.js')
+        const mockAI = makeMockAIService({ embedResponse: [] })
+        const mockDB = makeMockDB()
+        const svc = createRAGService({ db: mockDB, aiService: mockAI })
+
+        const result = await svc.answer('qué es la depresión')
+
+        assert.equal(result, null, 'Must return null when embed fails')
+        assert.equal(mockDB.queryCallCount, 0, 'DB must NOT be queried when embed fails')
+    })
+
+    test('no rows above similarity threshold → returns null', async () => {
+        const { createRAGService } = await import('../../services/ragService.js')
+        const mockAI = makeMockAIService()
+        // distance >= 0.25 means similarity <= 0.75 (below threshold)
+        const mockDB = makeMockDB([
+            { chunk_text: 'Texto poco relevante.', source_path: '/Libros/otro.pdf', distance: 0.30 },
+            { chunk_text: 'Más texto irrelevante.', source_path: '/Libros/otro.pdf', distance: 0.45 },
+        ])
+        const svc = createRAGService({ db: mockDB, aiService: mockAI })
+
+        const result = await svc.answer('información específica muy técnica')
+
+        assert.equal(result, null, 'Must return null when no chunks meet the threshold')
+    })
+
+    test('cache hit — second call with same query does NOT call embed again', async () => {
+        const { createRAGService } = await import('../../services/ragService.js')
+        const mockAI = makeMockAIService({ chatResponse: 'Respuesta en caché.' })
+        const mockDB = makeMockDB([
+            { chunk_text: 'Contenido relevante sobre mindfulness.', source_path: '/Libros/mindfulness.pdf', distance: 0.08 },
+        ])
+        // Shared cache across calls to simulate the same service instance
+        const sharedCache = new Map()
+        const svc = createRAGService({ db: mockDB, aiService: mockAI, cache: sharedCache })
+
+        const first = await svc.answer('qué es mindfulness')
+        const embedCountAfterFirst = mockAI.embedCallCount
+
+        const second = await svc.answer('qué es mindfulness')
+
+        assert.ok(first !== null)
+        assert.deepEqual(first, second, 'Cached result must equal first result')
+        assert.equal(mockAI.embedCallCount, embedCountAfterFirst, 'embed must NOT be called again on cache hit')
+    })
+})
+
+describe('ragService.ingest', () => {
+    test('processes text content, calls embed per chunk, returns {inserted, skipped}', async () => {
+        const { createRAGService } = await import('../../services/ragService.js')
+
+        const mockAI = makeMockAIService()
+        const dbRows = []
+        const mockDB = {
+            queryCallCount: 0,
+            async query(sql, params) {
+                this.queryCallCount++
+                if (sql.trim().toUpperCase().startsWith('INSERT')) {
+                    return { rows: [], rowCount: 1 }
+                }
+                return { rows: dbRows, rowCount: 0 }
+            },
+        }
+
+        // Build a fake text with enough words to produce at least 1 chunk
+        const fakeText = Array(400).fill('palabra').join(' ')
+
+        // Inject mock readFile and pdfParse to avoid real file I/O
+        const mockReadFile = async () => Buffer.from('dummy')
+        const mockPdfParse = async () => ({ text: fakeText })
+
+        const svc = createRAGService({
+            db: mockDB,
+            aiService: mockAI,
+            _readFile: mockReadFile,
+            _pdfParse: mockPdfParse,
+        })
+
+        const result = await svc.ingest({ filePath: '/fake/libro.pdf', category: 'psicoeducacion' })
+
+        assert.ok(typeof result === 'object', 'ingest must return an object')
+        assert.ok(typeof result.inserted === 'number', 'inserted must be a number')
+        assert.ok(typeof result.skipped === 'number', 'skipped must be a number')
+        assert.ok(result.inserted + result.skipped > 0, 'At least one chunk must be processed')
+        assert.ok(mockAI.embedCallCount > 0, 'embed must be called for each chunk')
+        assert.ok(mockDB.queryCallCount > 0, 'DB must be queried for each embedded chunk')
+    })
+})

--- a/bot/src/flows/knowledgeBase.js
+++ b/bot/src/flows/knowledgeBase.js
@@ -1,5 +1,6 @@
 import { addKeyword } from '@builderbot/bot'
 import { knowledgeService } from '../services/knowledgeBase.js'
+import { ragService } from '../services/ragService.js'
 
 const CATEGORY_LABELS = {
     horarios: 'Horarios',
@@ -73,6 +74,23 @@ export const searchFlow = addKeyword(['buscar', 'search'])
         { capture: true },
         async (ctx, { flowDynamic }) => {
             const input = ctx.body.toLowerCase().trim()
+
+            // Try RAG first — returns null when score < threshold or embed fails
+            try {
+                const ragResult = await ragService.answer(input)
+                if (ragResult !== null) {
+                    const sourceLine =
+                        ragResult.sources.length > 0
+                            ? `\n\n_Fuentes: ${ragResult.sources.join(', ')}_`
+                            : ''
+                    await flowDynamic(`${ragResult.answer}${sourceLine}`)
+                    return
+                }
+            } catch {
+                // RAG error — fall through to category-based lookup
+            }
+
+            // Fallback: existing category match → bot_faq lookup
             const matched = Object.keys(CATEGORY_LABELS).find(cat => input.includes(cat))
 
             if (!matched) {

--- a/bot/src/flows/knowledgeBase.js
+++ b/bot/src/flows/knowledgeBase.js
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { addKeyword } from '@builderbot/bot'
 import { knowledgeService } from '../services/knowledgeBase.js'
 import { ragService } from '../services/ragService.js'
@@ -81,7 +82,7 @@ export const searchFlow = addKeyword(['buscar', 'search'])
                 if (ragResult !== null) {
                     const sourceLine =
                         ragResult.sources.length > 0
-                            ? `\n\n_Fuentes: ${ragResult.sources.join(', ')}_`
+                            ? `\n\n_Fuentes: ${ragResult.sources.map(s => path.basename(s, path.extname(s))).join(', ')}_`
                             : ''
                     await flowDynamic(`${ragResult.answer}${sourceLine}`)
                     return

--- a/bot/src/scripts/ingestPdfs.js
+++ b/bot/src/scripts/ingestPdfs.js
@@ -52,7 +52,10 @@ try {
 import { ragService } from '../services/ragService.js'
 
 const TAG = '[ingestPdfs]'
-const LIBROS_PATH = process.env.LIBROS_PATH || path.join(process.cwd(), 'Libros')
+// Resolve relative to the repo root (3 levels up from bot/src/scripts/) so the
+// default works regardless of where `node` is invoked from.
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..')
+const LIBROS_PATH = process.env.LIBROS_PATH || path.join(REPO_ROOT, 'Libros')
 
 /**
  * Recopila recursivamente todos los archivos `.pdf` bajo un directorio raíz.

--- a/bot/src/scripts/ingestPdfs.js
+++ b/bot/src/scripts/ingestPdfs.js
@@ -1,0 +1,140 @@
+/**
+ * Script de ingestión de PDFs para la base de conocimiento RAG.
+ *
+ * Lee recursivamente todos los archivos `*.pdf` desde la carpeta definida por
+ * la variable de entorno `LIBROS_PATH` (por defecto: `<cwd>/Libros`).
+ * La categoría de cada documento se extrae del nombre de la carpeta padre inmediata.
+ *
+ * Ejecutar una sola vez (o cuando se agreguen nuevos libros):
+ *   node bot/src/scripts/ingestPdfs.js
+ *
+ * Variables de entorno requeridas (tomadas del .env del bot):
+ *   PGHOST, PGUSER, PGDATABASE, PGPASSWORD, PGPORT
+ *   OPENAI_API_KEY
+ *   LIBROS_PATH  (opcional — default: <cwd>/Libros)
+ *
+ * ---
+ *
+ * PDF ingestion script for the RAG knowledge base.
+ *
+ * Recursively reads all `*.pdf` files from the folder defined by the
+ * `LIBROS_PATH` env var (default: `<cwd>/Libros`).
+ * The category of each document is derived from its immediate parent folder name.
+ *
+ * Run once (or whenever new books are added):
+ *   node bot/src/scripts/ingestPdfs.js
+ *
+ * Required env vars (loaded from the bot's .env):
+ *   PGHOST, PGUSER, PGDATABASE, PGPASSWORD, PGPORT
+ *   OPENAI_API_KEY
+ *   LIBROS_PATH  (optional — default: <cwd>/Libros)
+ */
+
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+// Load .env from bot root — resolve relative to this script's location
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const botRoot = path.resolve(__dirname, '..', '..')
+
+// dotenv is not a listed dependency; load only if available, otherwise rely on
+// caller to inject env vars (e.g. via `dotenv -e .env node script.js`)
+try {
+    const requireLocal = createRequire(import.meta.url)
+    const dotenv = requireLocal('dotenv')
+    dotenv.config({ path: path.join(botRoot, '.env') })
+} catch {
+    // dotenv not available — env vars must be pre-loaded by the calling shell
+}
+
+import { ragService } from '../services/ragService.js'
+
+const TAG = '[ingestPdfs]'
+const LIBROS_PATH = process.env.LIBROS_PATH || path.join(process.cwd(), 'Libros')
+
+/**
+ * Recopila recursivamente todos los archivos `.pdf` bajo un directorio raíz.
+ *
+ * Recursively collects all `.pdf` files under a root directory.
+ *
+ * @param {string} dir - Directorio raíz / Root directory.
+ * @returns {Promise<string[]>} Rutas absolutas de todos los PDFs / Absolute paths of all PDFs.
+ */
+async function collectPDFs(dir) {
+    const entries = await fs.readdir(dir, { withFileTypes: true })
+    const results = []
+
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name)
+        if (entry.isDirectory()) {
+            const nested = await collectPDFs(fullPath)
+            results.push(...nested)
+        } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.pdf')) {
+            results.push(fullPath)
+        }
+    }
+
+    return results
+}
+
+/**
+ * Derive la categoría de un archivo a partir del nombre de su carpeta padre.
+ * Si el padre es el directorio raíz de libros, usa 'general'.
+ *
+ * Derives the category of a file from its immediate parent folder name.
+ * Falls back to 'general' if the parent is the books root directory.
+ *
+ * @param {string} filePath - Ruta absoluta del archivo / Absolute file path.
+ * @returns {string} Categoría derivada / Derived category.
+ */
+function deriveCategory(filePath) {
+    const parentDir = path.basename(path.dirname(filePath))
+    // If the file sits directly inside LIBROS_PATH, use 'general'
+    return path.dirname(filePath) === LIBROS_PATH ? 'general' : parentDir
+}
+
+async function main() {
+    console.log(`${TAG} Books root: ${LIBROS_PATH}`)
+
+    let pdfs
+    try {
+        pdfs = await collectPDFs(LIBROS_PATH)
+    } catch (err) {
+        console.error(`${TAG} Cannot read LIBROS_PATH: ${err.message}`)
+        process.exit(1)
+    }
+
+    if (pdfs.length === 0) {
+        console.log(`${TAG} No PDF files found under ${LIBROS_PATH}. Nothing to ingest.`)
+        process.exit(0)
+    }
+
+    console.log(`${TAG} Found ${pdfs.length} PDF(s). Starting ingestion...`)
+
+    let totalInserted = 0
+    let totalSkipped = 0
+
+    for (const filePath of pdfs) {
+        const filename = path.basename(filePath)
+        const category = deriveCategory(filePath)
+
+        console.log(`${TAG} Processing ${filename} (category: ${category})...`)
+
+        try {
+            const { inserted, skipped } = await ragService.ingest({ filePath, category })
+            console.log(`${TAG} ${filename}: inserted=${inserted} skipped=${skipped}`)
+            totalInserted += inserted
+            totalSkipped += skipped
+        } catch (err) {
+            // Per-file errors are logged but do not abort the entire run
+            console.error(`${TAG} Error processing ${filename}: ${err.message}`)
+        }
+    }
+
+    console.log(`${TAG} Done. Total inserted=${totalInserted} skipped=${totalSkipped}`)
+    process.exit(0)
+}
+
+main()

--- a/bot/src/services/ragService.js
+++ b/bot/src/services/ragService.js
@@ -1,0 +1,299 @@
+/**
+ * Servicio RAG (Retrieval-Augmented Generation) para la base de conocimiento psicoeducativa.
+ * Realiza búsqueda semántica sobre embeddings vectoriales almacenados en PostgreSQL
+ * y genera respuestas contextualizadas con GPT-4o.
+ *
+ * RAG service for the psychoeducational knowledge base.
+ * Performs semantic search over vector embeddings stored in PostgreSQL
+ * and generates contextualised responses using GPT-4o.
+ */
+
+import fs from 'node:fs/promises'
+import crypto from 'node:crypto'
+import pg from 'pg'
+import pdfParse from 'pdf-parse'
+import { aiService } from './aiService.js'
+
+const { Pool } = pg
+
+/**
+ * Mensaje de redirección para consultas de personalización clínica.
+ * Displayed when the user frames the query as a personal case.
+ *
+ * @type {string}
+ */
+const REDIRECT_MESSAGE =
+    'Solo un profesional puede evaluar tu situación personal. Te invito a agendar una consulta con uno de nuestros psicólogos. Escribí *agendar* para reservar tu turno.'
+
+/**
+ * Detecta si una consulta describe una situación personal del usuario
+ * que requiere derivación a un profesional, sin pasar por RAG.
+ *
+ * Detects whether a query describes a personal situation that must be
+ * redirected to a professional (never answered via RAG).
+ *
+ * @param {string} query - Consulta del usuario / User query.
+ * @returns {boolean}
+ */
+function isPersonalisedQuery(query) {
+    return /\b(yo\s+ten|mi\s+(amigo|familiar|hijo|hija|pareja)|creo\s+que\s+sufro|me\s+diagnos)/i.test(query)
+}
+
+/**
+ * Divide un texto en chunks de ~500 tokens con solapamiento de ~50 tokens.
+ * Aproximación: 1 token ≈ 0,75 palabras → 500 tokens ≈ 375 palabras, overlap ≈ 38 palabras.
+ * La división primaria es `\n\n` (párrafos); los límites se respetan reagrupando palabras.
+ *
+ * Splits text into ~500-token chunks with ~50-token overlap.
+ * Approximation: 1 token ≈ 0.75 words → 500 tokens ≈ 375 words, overlap ≈ 38 words.
+ * Primary split is `\n\n` (paragraphs); boundaries are respected by regrouping words.
+ *
+ * @param {string} text - Texto completo a fragmentar / Full text to chunk.
+ * @returns {string[]} Array de chunks / Array of chunks.
+ */
+function chunkText(text) {
+    const TARGET_WORDS = 375
+    const OVERLAP_WORDS = 38
+
+    // Flatten text into word array, preserving paragraph boundaries as empty strings
+    const paragraphs = text.split(/\n\n+/).map(p => p.trim()).filter(Boolean)
+    const allWords = []
+    for (const para of paragraphs) {
+        allWords.push(...para.split(/\s+/).filter(Boolean))
+    }
+
+    const chunks = []
+    let start = 0
+
+    while (start < allWords.length) {
+        const end = Math.min(start + TARGET_WORDS, allWords.length)
+        const slice = allWords.slice(start, end)
+        if (slice.length > 0) {
+            chunks.push(slice.join(' '))
+        }
+        start += TARGET_WORDS - OVERLAP_WORDS
+    }
+
+    return chunks
+}
+
+/**
+ * Genera una clave SHA-256 para el cache a partir de una consulta.
+ *
+ * Generates a SHA-256 cache key from a query string.
+ *
+ * @param {string} query - Consulta a hashear / Query to hash.
+ * @returns {string} Hash hexadecimal / Hexadecimal hash.
+ */
+function cacheKey(query) {
+    return crypto.createHash('sha256').update(query).digest('hex')
+}
+
+/**
+ * Crea una instancia del servicio RAG con dependencias inyectadas.
+ * Sigue el patrón factory para facilitar testing con mocks.
+ *
+ * Creates a RAG service instance with injected dependencies.
+ * Follows the factory pattern to enable testing with mocks.
+ *
+ * @param {{ db: object, aiService: object, cache?: Map<string, {value: any, expiresAt: number}> }} deps
+ * @param {object} deps.db - Adaptador de base de datos con método `query` / DB adapter with `query` method.
+ * @param {object} deps.aiService - Instancia del AI service / AI service instance.
+ * @param {Map} [deps.cache] - Cache Map opcional; si no se provee se crea uno interno / Optional cache Map; internal one created if omitted.
+ * @returns {object} Instancia del servicio RAG / RAG service instance.
+ */
+export function createRAGService({ db, aiService: injectedAIService, cache, _pdfParse, _readFile } = {}) {
+    // Allow injecting replacements for I/O dependencies in tests
+    const parsePDF = _pdfParse ?? pdfParse
+    const readFile = _readFile ?? fs.readFile
+    const _cache = cache ?? new Map()
+    const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+    /**
+     * Recupera un valor del cache si no ha expirado.
+     *
+     * Retrieves a cached value if not expired.
+     *
+     * @param {string} key
+     * @returns {any|undefined}
+     */
+    function getCache(key) {
+        const entry = _cache.get(key)
+        if (!entry) return undefined
+        if (Date.now() > entry.expiresAt) {
+            _cache.delete(key)
+            return undefined
+        }
+        return entry.value
+    }
+
+    /**
+     * Almacena un valor en el cache con TTL de 1 hora.
+     *
+     * Stores a value in the cache with a 1-hour TTL.
+     *
+     * @param {string} key
+     * @param {any} value
+     */
+    function setCache(key, value) {
+        _cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS })
+    }
+
+    return {
+        /**
+         * Responde una consulta general usando RAG: embed → búsqueda coseno → GPT-4o.
+         * Detecta personalización y redirige sin consultar RAG.
+         * Devuelve null cuando el embedding falla o no hay resultados por encima del umbral.
+         *
+         * Answers a general query using RAG: embed → cosine search → GPT-4o.
+         * Detects personalised queries and redirects without hitting RAG.
+         * Returns null when embedding fails or no results meet the threshold.
+         *
+         * @param {string} query - Consulta del usuario / User query.
+         * @param {string} [lang='es'] - Idioma de respuesta / Response language (reserved for future i18n).
+         * @returns {Promise<{answer: string, sources: string[]}|null>}
+         */
+        async answer(query, lang = 'es') {
+            // 1. Personalisation redirect — never goes through RAG
+            if (isPersonalisedQuery(query)) {
+                return { answer: REDIRECT_MESSAGE, sources: [] }
+            }
+
+            // 2. Cache check — avoids re-embedding identical queries
+            const key = cacheKey(query)
+            const cached = getCache(key)
+            if (cached !== undefined) return cached
+
+            // 3. Embed the query
+            const embedding = await injectedAIService.embed(query)
+            if (!embedding || embedding.length === 0) {
+                // API error path — let caller fall back to category lookup
+                return null
+            }
+
+            // 4. Cosine similarity search via pgvector (<=> = cosine distance, lower is better)
+            const vectorLiteral = `[${embedding.join(',')}]`
+            const result = await db.query(
+                `SELECT chunk_text, source_path,
+                        (embedding <=> $1::vector) AS distance
+                 FROM knowledge_embeddings
+                 ORDER BY embedding <=> $1::vector
+                 LIMIT 5`,
+                [vectorLiteral]
+            )
+
+            // 5. Threshold: keep only rows with cosine distance < 0.25 (similarity > 0.75)
+            const relevant = result.rows.filter(row => row.distance < 0.25)
+            if (relevant.length === 0) return null
+
+            // 6. Build context string for GPT-4o
+            const contextStr = relevant
+                .map((row, i) => `[${i + 1}] ${row.chunk_text}`)
+                .join('\n\n')
+
+            // 7. Generate contextualised response
+            const answer = await injectedAIService.complete({ user: query, context: contextStr })
+
+            // 8. Collect distinct source paths
+            const sources = [...new Set(relevant.map(row => row.source_path).filter(Boolean))]
+
+            const response = { answer, sources }
+
+            // 9. Store in cache
+            setCache(key, response)
+
+            return response
+        },
+
+        /**
+         * Ingesta un archivo PDF en la base de conocimiento vectorial.
+         * Parsea el PDF, divide en chunks, genera embeddings e inserta en PostgreSQL.
+         *
+         * Ingests a PDF file into the vector knowledge base.
+         * Parses the PDF, splits into chunks, generates embeddings and inserts into PostgreSQL.
+         *
+         * @param {{ filePath: string, category: string }} opts
+         * @param {string} opts.filePath - Ruta absoluta al archivo PDF / Absolute path to the PDF file.
+         * @param {string} opts.category - Categoría temática del documento / Thematic category of the document.
+         * @returns {Promise<{inserted: number, skipped: number}>}
+         */
+        async ingest({ filePath, category }) {
+            const buffer = await readFile(filePath)
+            const parsed = await parsePDF(buffer)
+            const chunks = chunkText(parsed.text)
+
+            let inserted = 0
+            let skipped = 0
+
+            for (let i = 0; i < chunks.length; i++) {
+                const chunk = chunks[i]
+                const embedding = await injectedAIService.embed(chunk)
+
+                if (!embedding || embedding.length === 0) {
+                    skipped++
+                    continue
+                }
+
+                const vectorLiteral = `[${embedding.join(',')}]`
+
+                const res = await db.query(
+                    `INSERT INTO knowledge_embeddings
+                        (id, chunk_index, chunk_text, embedding, source_path, category, created_at)
+                     VALUES
+                        (gen_random_uuid(), $1, $2, $3::vector, $4, $5, NOW())
+                     ON CONFLICT (source_path, chunk_index) DO NOTHING`,
+                    [i, chunk, vectorLiteral, filePath, category]
+                )
+
+                // rowCount === 0 means ON CONFLICT DO NOTHING fired (duplicate)
+                if (res.rowCount === 0) {
+                    skipped++
+                } else {
+                    inserted++
+                }
+            }
+
+            return { inserted, skipped }
+        },
+    }
+}
+
+// ── Singleton via Proxy — mismo patrón que aiService.js ──────────────────────
+
+let _instance = null
+
+/**
+ * Crea o reutiliza la instancia singleton del RAG service.
+ * Usa su propio pg.Pool con las variables de entorno PG estándar.
+ *
+ * Creates or reuses the singleton RAG service instance.
+ * Uses its own pg.Pool with standard PG environment variables.
+ *
+ * @returns {ReturnType<typeof createRAGService>}
+ */
+function _getInstance() {
+    if (!_instance) {
+        const pool = new Pool({
+            host: process.env.PGHOST,
+            user: process.env.PGUSER,
+            database: process.env.PGDATABASE,
+            password: process.env.PGPASSWORD,
+            port: parseInt(process.env.PGPORT || '5432', 10),
+            max: 3,
+            idleTimeoutMillis: 30000,
+            connectionTimeoutMillis: 5000,
+        })
+
+        _instance = createRAGService({ db: pool, aiService })
+    }
+    return _instance
+}
+
+/**
+ * Singleton proxy del RAG service. Permite uso directo sin instanciación manual.
+ * Lazy-initializes en el primer acceso, igual que aiService.
+ *
+ * Singleton proxy of the RAG service. Enables direct use without manual instantiation.
+ * Lazy-initializes on first access, mirroring aiService.
+ */
+export const ragService = new Proxy({}, { get: (_, k) => _getInstance()[k] })

--- a/bot/src/services/ragService.js
+++ b/bot/src/services/ragService.js
@@ -96,10 +96,12 @@ function cacheKey(query) {
  * Creates a RAG service instance with injected dependencies.
  * Follows the factory pattern to enable testing with mocks.
  *
- * @param {{ db: object, aiService: object, cache?: Map<string, {value: any, expiresAt: number}> }} deps
+ * @param {{ db: object, aiService: object, cache?: Map<string, {value: any, expiresAt: number}>, _pdfParse?: Function, _readFile?: Function }} deps
  * @param {object} deps.db - Adaptador de base de datos con método `query` / DB adapter with `query` method.
  * @param {object} deps.aiService - Instancia del AI service / AI service instance.
  * @param {Map} [deps.cache] - Cache Map opcional; si no se provee se crea uno interno / Optional cache Map; internal one created if omitted.
+ * @param {Function} [deps._pdfParse] - Override de pdf-parse para testing / pdf-parse override for testing.
+ * @param {Function} [deps._readFile] - Override de fs.readFile para testing / fs.readFile override for testing.
  * @returns {object} Instancia del servicio RAG / RAG service instance.
  */
 export function createRAGService({ db, aiService: injectedAIService, cache, _pdfParse, _readFile } = {}) {
@@ -177,7 +179,7 @@ export function createRAGService({ db, aiService: injectedAIService, cache, _pdf
                 `SELECT chunk_text, source_path,
                         (embedding <=> $1::vector) AS distance
                  FROM knowledge_embeddings
-                 ORDER BY embedding <=> $1::vector
+                 ORDER BY 3
                  LIMIT 5`,
                 [vectorLiteral]
             )


### PR DESCRIPTION
Closes #125

## Sprint W21 — PR2: Capa RAG (Retrieval-Augmented Generation)

### Cambios

| Archivo | Acción | Descripción |
|---------|--------|-------------|
| `bot/src/services/ragService.js` | Nuevo | Factory + Proxy singleton. `answer()`: cosine search (threshold 0.75), redirect personalización, cache SHA-256 TTL 1h. `ingest()`: chunker 500 tokens / 50 overlap |
| `bot/src/scripts/ingestPdfs.js` | Nuevo | CLI script para indexar PDFs de `/Libros/` en `knowledge_embeddings`. Ejecutar una vez post-merge |
| `bot/src/flows/knowledgeBase.js` | Modificado | `searchFlow` llama `ragService.answer()` primero. Si devuelve null → fallback a `bot_faq` lookup existente. Flujo de menú de categorías intacto |
| `bot/src/__tests__/services/ragService.test.cjs` | Nuevo | 6 tests: redirect personalización, answer con chunks, embed error → null, score bajo → null, cache hit, ingest counts |

### Comportamiento

- **Preguntas generales** (¿qué es la depresión?) → RAG sobre libros de /Libros/
- **Preguntas personales** (yo tengo..., mi amigo...) → redirect a agendar cita, nunca RAG
- **Score < 0.75** → null → cae al flujo bot_faq existente (sin romper nada)
- **Cache 1h** por query (SHA-256 key) para evitar embeddings redundantes

### Tests
52/52 pass (43 PR1 + 6 PR2 + 3 regresión)

### Pre-requisitos
- Migration `013_pgvector_embeddings.sql` aplicada en Railway antes del merge

### Post-merge
```bash
node bot/src/scripts/ingestPdfs.js
```