### PR TITLE
feat(sprint-w21-p3): TriageService + triageFlow + emergencyFlow + mainMenu distress guard

### DIFF
--- a/bot/src/__tests__/services/triageService.test.cjs
+++ b/bot/src/__tests__/services/triageService.test.cjs
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, describe, before } = require('node:test')
+const { test, describe } = require('node:test')
 const assert = require('node:assert/strict')
 
 // ── Mock factories ────────────────────────────────────────────────────────────
@@ -80,6 +80,20 @@ describe('triageService.nextTurn', () => {
 
         assert.equal(result.done, true, 'done must be true when AI signals done')
         assert.equal(result.newState.step, 9, 'step must advance to 9')
+    })
+
+    test('step=9 with AI done:false → forced done=true by newStep >= 9 guard', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+
+        // AI incorrectly returns done:false on step 9
+        const aiResponse = { next_question: 'Una más...', extracted_score: 1, step: 9, done: false }
+        const svc = createTriageService({ db: makeMockDB(), aiService: makeMockAIService(aiResponse) })
+
+        const currentState = { step: 8, responses: Array(8).fill('sí'), scores: Array(8).fill(1) }
+        const result = await svc.nextTurn({ phone: '+57123', userText: 'sí', currentState })
+
+        assert.equal(result.done, true, 'done must be forced true when newStep >= 9 regardless of AI response')
+        assert.equal(result.newState.step, 9)
     })
 
     test('completeJSON returns {} (error) → returns safe fallback question, does NOT throw', async () => {
@@ -189,6 +203,22 @@ describe('triageService.saveAssessment', () => {
         })
 
         assert.ok(insertCalled, 'db INSERT must be called')
+    })
+
+    test('DB throws → error is silenced, does NOT throw', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+
+        const errorDB = { async query() { throw new Error('connection refused') } }
+        const svc = createTriageService({ db: errorDB, aiService: makeMockAIService() })
+
+        await assert.doesNotReject(async () => {
+            await svc.saveAssessment({
+                phone: '+57123456789',
+                scores: [1, 1, 1, 1, 1, 0, 0, 0, 0],
+                urgency: 'mild',
+                recommendedAction: 'Se recomienda hablar con un profesional.',
+            })
+        }, 'saveAssessment must not throw even when DB fails')
     })
 })
 

--- a/bot/src/__tests__/services/triageService.test.cjs
+++ b/bot/src/__tests__/services/triageService.test.cjs
@@ -1,0 +1,227 @@
+'use strict'
+
+const { test, describe, before } = require('node:test')
+const assert = require('node:assert/strict')
+
+// ── Mock factories ────────────────────────────────────────────────────────────
+
+/**
+ * Builds a mock AI service with a controlled completeJSON response.
+ *
+ * @param {object} [jsonResponse={}] - Response returned by completeJSON.
+ * @returns {object} Mock AI service compatible with createTriageService DI.
+ */
+function makeMockAIService(jsonResponse = {}) {
+    return {
+        async completeJSON(opts) { return jsonResponse },
+        async complete(opts) { return 'respuesta' },
+        async embed(text) { return [] },
+    }
+}
+
+/**
+ * Builds a mock DB that returns a fixed set of rows for any query.
+ *
+ * @param {Array<object>} [rows=[]] - Rows returned by SELECT queries.
+ * @returns {object} Mock DB with a query() method.
+ */
+function makeMockDB(rows = []) {
+    return {
+        async query(sql, params) {
+            if (sql.trim().toUpperCase().startsWith('INSERT')) return { rows: [], rowCount: 1 }
+            return { rows, rowCount: rows.length }
+        },
+    }
+}
+
+// ── nextTurn tests ────────────────────────────────────────────────────────────
+
+describe('triageService.nextTurn', () => {
+    test('first turn (null state) → returns nextQuestion, step=1, done=false', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+
+        const aiResponse = {
+            next_question: '¿Con qué frecuencia te has sentido sin energía?',
+            extracted_score: 1,
+            step: 2,
+            done: false,
+        }
+        const svc = createTriageService({ db: makeMockDB(), aiService: makeMockAIService(aiResponse) })
+
+        const result = await svc.nextTurn({ phone: '+57123', userText: 'Varios días', currentState: null })
+
+        assert.equal(typeof result.nextQuestion, 'string', 'nextQuestion must be a string')
+        assert.ok(result.nextQuestion.length > 0, 'nextQuestion must be non-empty')
+        assert.equal(result.newState.step, 1, 'step must be 1 after first turn')
+        assert.equal(result.done, false, 'done must be false on first turn')
+        assert.deepEqual(result.newState.responses, ['Varios días'])
+        assert.deepEqual(result.newState.scores, [1])
+    })
+
+    test('last turn (step=8 → AI returns done:true) → done=true', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+
+        const aiResponse = {
+            next_question: 'Gracias por compartir todo esto. Ha sido muy valioso.',
+            extracted_score: 2,
+            step: 9,
+            done: true,
+        }
+        const svc = createTriageService({ db: makeMockDB(), aiService: makeMockAIService(aiResponse) })
+
+        // State with 8 answers already = step 8
+        const currentState = {
+            step: 8,
+            responses: Array(8).fill('algunos días'),
+            scores: Array(8).fill(1),
+        }
+
+        const result = await svc.nextTurn({ phone: '+57123', userText: 'No, nunca', currentState })
+
+        assert.equal(result.done, true, 'done must be true when AI signals done')
+        assert.equal(result.newState.step, 9, 'step must advance to 9')
+    })
+
+    test('completeJSON returns {} (error) → returns safe fallback question, does NOT throw', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+
+        const svc = createTriageService({ db: makeMockDB(), aiService: makeMockAIService({}) })
+
+        let result
+        await assert.doesNotReject(async () => {
+            result = await svc.nextTurn({ phone: '+57123', userText: 'hola', currentState: null })
+        })
+
+        assert.equal(typeof result.nextQuestion, 'string', 'nextQuestion must be a string even on AI error')
+        assert.ok(result.nextQuestion.length > 0, 'fallback question must be non-empty')
+        assert.equal(result.newState.scores[0], 0, 'score must default to 0 on error')
+    })
+})
+
+// ── finalize tests ────────────────────────────────────────────────────────────
+
+describe('triageService.finalize', () => {
+    test('score 0-4 → urgency minimal, hotline null', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+        const svc = createTriageService({ db: makeMockDB(), aiService: makeMockAIService() })
+
+        const result = svc.finalize({ scores: [1, 0, 1, 0, 1, 0, 0, 0, 1] }) // sum=4
+
+        assert.equal(result.urgency, 'minimal')
+        assert.equal(result.hotline, null)
+        assert.equal(result.score, 4)
+    })
+
+    test('score 5-9 → urgency mild, hotline null', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+        const svc = createTriageService({ db: makeMockDB(), aiService: makeMockAIService() })
+
+        const result = svc.finalize({ scores: [1, 1, 1, 1, 1, 0, 0, 0, 0] }) // sum=5
+
+        assert.equal(result.urgency, 'mild')
+        assert.equal(result.hotline, null)
+        assert.equal(result.score, 5)
+    })
+
+    test('score 10-14 → urgency moderate, hotline null', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+        const svc = createTriageService({ db: makeMockDB(), aiService: makeMockAIService() })
+
+        const result = svc.finalize({ scores: [2, 2, 2, 2, 2, 0, 0, 0, 0] }) // sum=10
+
+        assert.equal(result.urgency, 'moderate')
+        assert.equal(result.hotline, null)
+        assert.equal(result.score, 10)
+    })
+
+    test('score 15-27 → urgency severe, hotline non-null', async () => {
+        process.env.CRISIS_HOTLINE = 'TestLine123'
+        const { createTriageService } = await import('../../services/triageService.js')
+        const svc = createTriageService({ db: makeMockDB(), aiService: makeMockAIService() })
+
+        const result = svc.finalize({ scores: [2, 2, 2, 2, 2, 2, 2, 1, 0] }) // sum=15
+
+        assert.equal(result.urgency, 'severe')
+        assert.ok(result.hotline !== null, 'hotline must be non-null for severe')
+        assert.ok(result.hotline.includes('TestLine123'), 'hotline must reflect env var')
+        assert.equal(result.score, 15)
+    })
+
+    test('boundary score 27 → urgency severe', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+        const svc = createTriageService({ db: makeMockDB(), aiService: makeMockAIService() })
+
+        const result = svc.finalize({ scores: [3, 3, 3, 3, 3, 3, 3, 3, 3] }) // sum=27
+
+        assert.equal(result.urgency, 'severe')
+        assert.equal(result.score, 27)
+        assert.ok(result.hotline !== null)
+    })
+})
+
+// ── saveAssessment tests ──────────────────────────────────────────────────────
+
+describe('triageService.saveAssessment', () => {
+    test('calls db INSERT without throwing on success', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+
+        let insertCalled = false
+        const mockDB = {
+            async query(sql, params) {
+                if (sql.trim().toUpperCase().startsWith('INSERT')) {
+                    insertCalled = true
+                    return { rows: [], rowCount: 1 }
+                }
+                // lookupPatientId SELECT
+                return { rows: [], rowCount: 0 }
+            },
+        }
+
+        const svc = createTriageService({ db: mockDB, aiService: makeMockAIService() })
+
+        await assert.doesNotReject(async () => {
+            await svc.saveAssessment({
+                phone: '+57123456789',
+                scores: [1, 1, 1, 1, 1, 0, 0, 0, 0],
+                urgency: 'mild',
+                recommendedAction: 'Se recomienda hablar con un profesional.',
+            })
+        })
+
+        assert.ok(insertCalled, 'db INSERT must be called')
+    })
+})
+
+// ── hasUpcomingAppointment tests ──────────────────────────────────────────────
+
+describe('triageService.hasUpcomingAppointment', () => {
+    test('returns true when DB returns rows (appointment found)', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+        const svc = createTriageService({ db: makeMockDB([{ '?column?': 1 }]), aiService: makeMockAIService() })
+
+        const result = await svc.hasUpcomingAppointment('+57123456789')
+
+        assert.equal(result, true)
+    })
+
+    test('returns false when DB returns empty rows (no appointment)', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+        const svc = createTriageService({ db: makeMockDB([]), aiService: makeMockAIService() })
+
+        const result = await svc.hasUpcomingAppointment('+57123456789')
+
+        assert.equal(result, false)
+    })
+
+    test('returns false when DB throws (error is silenced)', async () => {
+        const { createTriageService } = await import('../../services/triageService.js')
+        const errorDB = {
+            async query() { throw new Error('connection refused') },
+        }
+        const svc = createTriageService({ db: errorDB, aiService: makeMockAIService() })
+
+        const result = await svc.hasUpcomingAppointment('+57123456789')
+
+        assert.equal(result, false)
+    })
+})

--- a/bot/src/flows/mainMenu.js
+++ b/bot/src/flows/mainMenu.js
@@ -1,12 +1,66 @@
+/**
+ * Flujo del menú principal con detección de angustia emocional.
+ * Antes de responder el saludo o menú normal, verifica si el mensaje contiene señales de crisis.
+ * Si detecta angustia Y el usuario no tiene turno próximo → redirige al triage PHQ-9.
+ * Si detecta angustia Y el usuario tiene turno → mensaje empático que recuerda la cita.
+ *
+ * Main menu flow with emotional distress detection.
+ * Before responding normally to greetings or menu, checks whether the message contains crisis signals.
+ * If distress detected AND no upcoming appointment → redirects to PHQ-9 triage.
+ * If distress detected AND has appointment → empathic message reminding them of the appointment.
+ */
+
 import { addAnswer, addKeyword } from '@builderbot/bot'
+import { detect } from '../utils/distressDetector.js'
+import { triageService } from '../services/triageService.js'
+import { triageFlow } from './triage.js'
+
+/**
+ * Mensaje empático cuando el usuario muestra angustia pero ya tiene una cita agendada.
+ * Empathic redirect message when the user shows distress but already has a scheduled appointment.
+ *
+ * @type {string}
+ */
+const EMPATHIC_REDIRECT =
+    'Escucho que estás pasando un momento difícil. Ya tenés una cita agendada. ' +
+    'Si necesitás hablar, tu profesional está esperándote. Escribí *agendar* para ver los detalles.'
+
+/**
+ * Guard de angustia emocional. Se ejecuta antes de cada respuesta de menú.
+ * Devuelve true si manejó la situación (y el flujo normal no debe continuar),
+ * false si todo está bien y el menú puede seguir su curso normal.
+ *
+ * Emotional distress guard. Runs before each menu reply.
+ * Returns true if it handled the situation (and the normal flow should NOT continue),
+ * false if everything is fine and the normal menu can proceed.
+ *
+ * @param {object} ctx - Contexto del mensaje BuilderBot / BuilderBot message context.
+ * @param {{ gotoFlow: Function, flowDynamic: Function }} helpers - Helpers del flow / Flow helpers.
+ * @returns {Promise<boolean>}
+ */
+async function distressGuard(ctx, { gotoFlow, flowDynamic }) {
+    if (!detect(ctx.body)) return false
+
+    const hasAppt = await triageService.hasUpcomingAppointment(ctx.from)
+    if (hasAppt) {
+        await flowDynamic(EMPATHIC_REDIRECT)
+        return true
+    }
+
+    await gotoFlow(triageFlow)
+    return true
+}
 
 export const mainMenuFlow = [
     addKeyword(['hola', 'hello', 'ola', 'buenas'])
+        .addAction(async (ctx, helpers) => { if (await distressGuard(ctx, helpers)) return })
         .addAnswer('¡Hola! 👋 Soy tu Asistente Psicológico.\n\nEstoy aquí para ayudarte con tus citas y gestión clínica.\n\n*¿En qué puedo ayudarte?*\n\n  1️⃣ Nueva Cita — escribí *agendar*\n  2️⃣ Mi Historia Clínica — escribí *historia*\n  3️⃣ Información — escribí *info*\n  ❓ Ayuda — escribí *ayuda*'),
 
     addKeyword('AYUDA')
+        .addAction(async (ctx, helpers) => { if (await distressGuard(ctx, helpers)) return })
         .addAnswer('*Menú de Ayuda*\n\n📅 *Nueva Cita* - Programar una cita\n📋 *Mi Historia Clínica* - Ver mi información\n❓ *Ayuda* - Ver este menú\n\nEscribí una opción para comenzar.'),
 
     addKeyword('MENU')
-        .addAnswer('*Menú Principal*\n\n  1️⃣ Nueva Cita — escribí *agendar*\n  2️⃣ Historia Clínica — escribí *historia*\n  3️⃣ Información — escribí *info*\n  ❓ Ayuda — escribí *ayuda*')
+        .addAction(async (ctx, helpers) => { if (await distressGuard(ctx, helpers)) return })
+        .addAnswer('*Menú Principal*\n\n  1️⃣ Nueva Cita — escribí *agendar*\n  2️⃣ Historia Clínica — escribí *historia*\n  3️⃣ Información — escribí *info*\n  ❓ Ayuda — escribí *ayuda*'),
 ]

--- a/bot/src/flows/triage.js
+++ b/bot/src/flows/triage.js
@@ -1,0 +1,107 @@
+/**
+ * Flujo de triage conversacional basado en PHQ-9.
+ * Conduce la entrevista de salud mental, evalúa la urgencia y redirige al flujo apropiado.
+ *
+ * Conversational PHQ-9-based triage flow.
+ * Conducts the mental health interview, evaluates urgency and redirects to the appropriate flow.
+ */
+
+import { addKeyword, EVENTS } from '@builderbot/bot'
+import { triageService } from '../services/triageService.js'
+import { appointmentFlow } from './appointment.js'
+
+/**
+ * Mensaje de crisis que se envía cuando la urgencia es "severe".
+ * Crisis message sent when urgency is "severe".
+ *
+ * @type {string}
+ */
+const CRISIS_MESSAGE = `Lo que me contás es importante y quiero que sepas que no estás solo/a.
+
+Podés llamar ahora: ${process.env.CRISIS_HOTLINE || '106 (Bogotá) / 192 (Línea Nacional Colombia)'}
+
+También puedo ayudarte a reservar un turno urgente con un profesional. Escribí *agendar* cuando estés listo/a.`
+
+/**
+ * Flujo de emergencia: se activa cuando el triage detecta urgencia "severe".
+ * Entrega el mensaje de crisis con la línea de ayuda y ofrece un turno urgente.
+ *
+ * Emergency flow: activated when triage detects "severe" urgency.
+ * Delivers the crisis message with the helpline and offers an urgent slot.
+ *
+ * @type {import('@builderbot/bot').TFlow}
+ */
+export const emergencyFlow = addKeyword(EVENTS.ACTION)
+    .addAction(async (ctx, { flowDynamic }) => {
+        await flowDynamic(CRISIS_MESSAGE)
+    })
+
+/**
+ * Flujo principal de triage PHQ-9.
+ * - Primer turno: envía mensaje introductorio y captura la primera respuesta.
+ * - Turnos siguientes: procesa la respuesta, actualiza el estado y continúa o finaliza.
+ * - Al terminar: calcula urgencia, persiste en DB y redirige a emergencyFlow o appointmentFlow.
+ *
+ * Main PHQ-9 triage flow.
+ * - First turn: sends an intro message and captures the first response.
+ * - Subsequent turns: processes the answer, updates state and continues or finalises.
+ * - On completion: calculates urgency, persists to DB and redirects to emergencyFlow or appointmentFlow.
+ *
+ * @type {import('@builderbot/bot').TFlow}
+ */
+export const triageFlow = addKeyword(EVENTS.ACTION)
+    .addAnswer(
+        '',
+        { capture: true },
+        async (ctx, { flowDynamic, state, gotoFlow }) => {
+            const triageState = (await state.getMyState())?._triage ?? null
+
+            // First turn: introduce the interview before processing
+            // Primer turno: presentar la entrevista antes de procesar
+            if (!triageState || triageState.step === 0) {
+                await flowDynamic(
+                    'Antes de continuar, quiero hacerte unas preguntas breves para entender mejor cómo estás. ' +
+                    'Es confidencial y no tardará mucho.\n\n' +
+                    '¿Cómo te has sentido durante las últimas dos semanas?'
+                )
+            }
+
+            const { nextQuestion, done, newState } = await triageService.nextTurn({
+                phone: ctx.from,
+                userText: ctx.body,
+                currentState: triageState,
+            })
+
+            await state.update({ _triage: newState })
+
+            if (!done) {
+                // Still more questions — show next and loop back
+                // Aún quedan preguntas — mostrar la siguiente y volver a capturar
+                await flowDynamic(nextQuestion)
+                return gotoFlow(triageFlow)
+            }
+
+            // --- Triage complete ---
+            const { score, urgency, recommendedAction } = triageService.finalize({
+                scores: newState.scores,
+            })
+
+            await triageService.saveAssessment({
+                phone: ctx.from,
+                scores: newState.scores,
+                urgency,
+                recommendedAction,
+            })
+
+            // Clear triage state after completion
+            // Limpiar estado del triage al terminar
+            await state.update({ _triage: null })
+
+            if (urgency === 'severe') {
+                return gotoFlow(emergencyFlow)
+            }
+
+            await flowDynamic(recommendedAction)
+            return gotoFlow(appointmentFlow)
+        }
+    )

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -32,6 +32,7 @@ import { appointmentFlow, primeraVezFlow, seguimientoFlow, appointmentStatusFlow
 import { knowledgeBaseFlow, searchFlow } from './flows/knowledgeBase.js'
 import { clinicalHistoryFlow } from './flows/clinicalHistory.js'
 import { registrationFlow } from './flows/registration.js'
+import { triageFlow, emergencyFlow } from './flows/triage.js'
 
 const helpFlow = addKeyword(['ayuda', 'help', 'socorro'])
     .addAnswer('*Opciones disponibles:*\n\n📅 Agendar / Cita\n📋 Mi Historia Clínica\n📚 Biblioteca\n🏠 Menú\n\n*Escribí una opción.*')
@@ -89,6 +90,8 @@ const main = async () => {
     })
 
     const flow = createFlow([
+        triageFlow,
+        emergencyFlow,
         helpFlow,
         ...mainMenuFlow,
         appointmentFlow,

--- a/bot/src/services/triageService.js
+++ b/bot/src/services/triageService.js
@@ -1,0 +1,290 @@
+/**
+ * Servicio de triage conversacional basado en el cuestionario PHQ-9.
+ * Conduce una entrevista empática de 9 turnos, calcula puntaje e inserta el resultado en la DB.
+ *
+ * Conversational triage service based on the PHQ-9 questionnaire.
+ * Conducts an empathic 9-turn interview, calculates the score and persists the result to the DB.
+ */
+
+import pg from 'pg'
+import { aiService } from './aiService.js'
+import { normalizePhone, lookupPatientId } from '../utils/normalizePhone.js'
+
+const { Pool } = pg
+
+/**
+ * Las 9 preguntas del PHQ-9 en español, numeradas.
+ * The 9 PHQ-9 questions in Spanish, numbered.
+ *
+ * @type {string}
+ */
+const PHQ9_QUESTIONS = `
+1. Poco interés o placer en hacer las cosas (0=Nunca, 1=Varios días, 2=Más de la mitad de los días, 3=Casi todos los días)
+2. Sentirse decaído/a, deprimido/a o sin esperanza
+3. Dificultad para dormir, quedarse dormido/a o dormir demasiado
+4. Sentirse cansado/a o con poca energía
+5. Falta de apetito o comer en exceso
+6. Sentirse mal consigo mismo/a, sentirse un fracaso o sentir que se ha fallado a sí mismo/a o a su familia
+7. Dificultad para concentrarse en actividades como leer el periódico o ver televisión
+8. Moverse o hablar tan lento que otras personas lo han notado, o lo contrario: estar tan inquieto/a que se mueve más de lo habitual
+9. Pensamiento de que estaría mejor muerto/a o de hacerse algún daño
+`.trim()
+
+/**
+ * System prompt del PHQ-9 para completeJSON.
+ * PHQ-9 system prompt for completeJSON.
+ *
+ * @type {string}
+ */
+const PHQ9_SYSTEM_PROMPT = `Sos un asistente que realiza el PHQ-9 de manera conversacional y empática.
+Las 9 preguntas del PHQ-9 son:
+${PHQ9_QUESTIONS}
+
+Para cada turno del usuario devolvé ÚNICAMENTE este JSON:
+{ "next_question": string, "extracted_score": number (0-3), "step": number (1-9), "done": boolean }
+
+Reglas:
+- "extracted_score" es el puntaje (0-3) que inferís de la respuesta del usuario para la pregunta actual.
+- "step" es el número de la SIGUIENTE pregunta a hacer (avanza de 1 en 1).
+- Si el usuario ya respondió la pregunta 9, poné "done": true y "step": 9. "next_question" debe ser un cierre empático.
+- NUNCA diagnosticás. NUNCA das tratamiento. Conducís la entrevista con calidez y sin prisa.
+- Si la respuesta del usuario es ambigua, elegí el score más conservador (menor).`
+
+/**
+ * Línea de crisis por defecto cuando no está configurada en entorno.
+ * Default crisis hotline when not configured in environment.
+ *
+ * @type {string}
+ */
+const DEFAULT_HOTLINE = '106 (Bogotá) / 192 (Línea Nacional Colombia)'
+
+/**
+ * Mapea un puntaje PHQ-9 a un nivel de urgencia.
+ * Maps a PHQ-9 score to an urgency level.
+ *
+ * @param {number} score - Puntaje total (0–27) / Total score (0–27).
+ * @returns {'minimal'|'mild'|'moderate'|'severe'}
+ */
+function mapUrgency(score) {
+    if (score <= 4) return 'minimal'
+    if (score <= 9) return 'mild'
+    if (score <= 14) return 'moderate'
+    return 'severe'
+}
+
+/**
+ * Crea una instancia del servicio de triage con dependencias inyectadas.
+ * Sigue el patrón factory para facilitar testing con mocks.
+ *
+ * Creates a triage service instance with injected dependencies.
+ * Follows the factory pattern to enable testing with mocks.
+ *
+ * @param {{ db: object, aiService: object }} deps
+ * @param {object} deps.db - Instancia de pg.Pool con método `query` / pg.Pool instance with `query` method.
+ * @param {object} deps.aiService - Instancia del AI service / AI service instance.
+ * @returns {object} Instancia del servicio de triage / Triage service instance.
+ */
+export function createTriageService({ db, aiService: injectedAIService }) {
+    return {
+        /**
+         * Avanza un turno de la entrevista PHQ-9 basándose en el estado actual.
+         * Llama a aiService.completeJSON para extraer el score y la siguiente pregunta.
+         *
+         * Advances one turn of the PHQ-9 interview based on current state.
+         * Calls aiService.completeJSON to extract the score and next question.
+         *
+         * @param {{ phone: string, userText: string, currentState: object|null }} params
+         * @param {string} params.phone - Número de teléfono del usuario / User phone number.
+         * @param {string} params.userText - Respuesta del usuario en este turno / User's answer this turn.
+         * @param {object|null} params.currentState - Estado PHQ-9 actual o null para iniciar / Current PHQ-9 state or null to start.
+         * @param {number} [params.currentState.step] - Número de la pregunta actual (0-based) / Current question number (0-based).
+         * @param {string[]} [params.currentState.responses] - Respuestas del usuario / User responses.
+         * @param {number[]} [params.currentState.scores] - Puntajes extraídos / Extracted scores.
+         * @returns {Promise<{nextQuestion: string, done: boolean, newState: {step: number, responses: string[], scores: number[]}}>}
+         */
+        async nextTurn({ phone, userText, currentState }) {
+            const state = currentState && typeof currentState.step === 'number'
+                ? currentState
+                : { step: 0, responses: [], scores: [] }
+
+            const currentStep = state.step // number of questions answered so far
+
+            let aiResult
+            try {
+                aiResult = await injectedAIService.completeJSON({
+                    system: PHQ9_SYSTEM_PROMPT,
+                    user: `Pregunta actual: ${currentStep + 1}. Respuesta del usuario: "${userText}"`,
+                })
+            } catch {
+                aiResult = {}
+            }
+
+            // Fallback: if completeJSON returns {} or malformed, keep moving forward safely
+            const isMalformed = !aiResult || typeof aiResult !== 'object' || typeof aiResult.next_question !== 'string'
+
+            const extractedScore = isMalformed
+                ? 0
+                : Math.max(0, Math.min(3, Number(aiResult.extracted_score) || 0))
+
+            const newStep = currentStep + 1
+
+            // Determine if triage is done
+            const doneFlagFromAI = !isMalformed && aiResult.done === true
+            const done = doneFlagFromAI || newStep >= 9
+
+            const safeNextQuestion = isMalformed
+                ? 'Gracias por compartir. ¿Podés contarme un poco más sobre cómo te has sentido?'
+                : aiResult.next_question
+
+            const newState = {
+                step: newStep,
+                responses: [...state.responses, userText],
+                scores: [...state.scores, extractedScore],
+            }
+
+            return { nextQuestion: safeNextQuestion, done, newState }
+        },
+
+        /**
+         * Calcula el puntaje final del PHQ-9 y determina la urgencia y acción recomendada.
+         * Recibe los scores directamente para evitar una lectura extra de DB.
+         *
+         * Calculates the final PHQ-9 score and determines urgency and recommended action.
+         * Accepts scores directly to avoid an extra DB read.
+         *
+         * @param {{ scores: number[] }} params
+         * @param {number[]} params.scores - Array de puntajes extraídos (0-3 cada uno) / Array of extracted scores (0-3 each).
+         * @returns {{ score: number, urgency: string, recommendedAction: string, hotline: string|null }}
+         */
+        finalize({ scores }) {
+            const score = scores.reduce((a, b) => a + b, 0)
+            const urgency = mapUrgency(score)
+            const hotline = process.env.CRISIS_HOTLINE || DEFAULT_HOTLINE
+
+            let recommendedAction
+            if (urgency === 'minimal' || urgency === 'mild') {
+                recommendedAction = 'Se recomienda hablar con un profesional para mayor orientación.'
+            } else if (urgency === 'moderate') {
+                recommendedAction = 'Es importante que agendés una consulta pronto. Escribí *agendar*.'
+            } else {
+                // severe
+                recommendedAction = `Necesitás atención urgente. ${hotline} | Escribí *agendar* para un turno de urgencia.`
+            }
+
+            return {
+                score,
+                urgency,
+                recommendedAction,
+                hotline: urgency === 'severe' ? hotline : null,
+            }
+        },
+
+        /**
+         * Persiste el resultado del triage en la tabla `triage_assessments`.
+         * Silencia errores: el flujo no debe romperse si el INSERT falla.
+         *
+         * Persists the triage result to the `triage_assessments` table.
+         * Errors are silenced: the flow must not break if the INSERT fails.
+         *
+         * @param {{ phone: string, scores: number[], urgency: string, recommendedAction: string }} params
+         * @param {string} params.phone - Número de teléfono / Phone number.
+         * @param {number[]} params.scores - Array de puntajes (0-3) / Array of scores (0-3).
+         * @param {string} params.urgency - Nivel de urgencia / Urgency level.
+         * @param {string} params.recommendedAction - Texto de acción recomendada / Recommended action text.
+         * @returns {Promise<void>}
+         */
+        async saveAssessment({ phone, scores, urgency, recommendedAction }) {
+            try {
+                const normalizedPhone = normalizePhone(phone)
+                const patientId = await lookupPatientId(db, normalizedPhone)
+                const totalScore = scores.reduce((a, b) => a + b, 0)
+
+                await db.query(
+                    `INSERT INTO triage_assessments
+                        (phone, phq9_responses, phq9_score, urgency_level, recommended_action, patient_id)
+                     VALUES ($1, $2::jsonb, $3, $4, $5, $6)`,
+                    [
+                        normalizedPhone,
+                        JSON.stringify(scores),
+                        totalScore,
+                        urgency,
+                        recommendedAction,
+                        patientId,
+                    ]
+                )
+            } catch (err) {
+                console.error('[triageService.saveAssessment] error:', err?.message ?? err)
+            }
+        },
+
+        /**
+         * Verifica si el usuario tiene una cita programada en las próximas N horas.
+         * Consulta directamente la tabla `appointments` sin depender de appointmentService.
+         *
+         * Checks whether the user has a scheduled appointment in the next N hours.
+         * Queries the `appointments` table directly, without depending on appointmentService.
+         *
+         * @param {string} phone - Número de teléfono del usuario / User phone number.
+         * @param {number} [hoursAhead=48] - Ventana de tiempo en horas / Time window in hours.
+         * @returns {Promise<boolean>} true si tiene cita, false en caso contrario o error / true if has appointment, false otherwise or on error.
+         */
+        async hasUpcomingAppointment(phone, hoursAhead = 48) {
+            try {
+                const normalizedPhone = normalizePhone(phone)
+                const result = await db.query(
+                    `SELECT 1 FROM appointments a
+                     JOIN patients p ON a.patient_id = p.id
+                     WHERE p.phone = $1
+                       AND a.status = 'scheduled'
+                       AND a.scheduled_at BETWEEN NOW() AND NOW() + ($2 || ' hours')::interval
+                     LIMIT 1`,
+                    [normalizedPhone, String(hoursAhead)]
+                )
+                return result.rows.length > 0
+            } catch (err) {
+                console.error('[triageService.hasUpcomingAppointment] error:', err?.message ?? err)
+                return false
+            }
+        },
+    }
+}
+
+// ── Singleton via Proxy — mismo patrón que ragService.js ─────────────────────
+
+let _instance = null
+
+/**
+ * Crea o reutiliza la instancia singleton del triage service.
+ * Usa su propio pg.Pool con las variables de entorno PG estándar.
+ *
+ * Creates or reuses the singleton triage service instance.
+ * Uses its own pg.Pool with standard PG environment variables.
+ *
+ * @returns {ReturnType<typeof createTriageService>}
+ */
+function _getInstance() {
+    if (!_instance) {
+        const pool = new Pool({
+            host: process.env.PGHOST,
+            user: process.env.PGUSER,
+            database: process.env.PGDATABASE,
+            password: process.env.PGPASSWORD,
+            port: parseInt(process.env.PGPORT || '5432', 10),
+            max: 3,
+            idleTimeoutMillis: 30000,
+            connectionTimeoutMillis: 5000,
+        })
+
+        _instance = createTriageService({ db: pool, aiService })
+    }
+    return _instance
+}
+
+/**
+ * Singleton proxy del triage service. Permite uso directo sin instanciación manual.
+ * Lazy-initializes en el primer acceso, igual que ragService.
+ *
+ * Singleton proxy of the triage service. Enables direct use without manual instantiation.
+ * Lazy-initializes on first access, mirroring ragService.
+ */
+export const triageService = new Proxy({}, { get: (_, k) => _getInstance()[k] })


### PR DESCRIPTION
Closes #127

## Sprint W21 — PR3: Capa de Triaje (PHQ-9 Conversacional)

### Cambios

| Archivo | Acción | Descripción |
|---------|--------|-------------|
| `bot/src/services/triageService.js` | Nuevo | `nextTurn()` PHQ-9 conversacional via `completeJSON`. `finalize()` mapa urgencia 0-27. `saveAssessment()` → `triage_assessments`. `hasUpcomingAppointment()` direct DB |
| `bot/src/flows/triage.js` | Nuevo | `triageFlow`: loop `EVENTS.ACTION` + state en `contact.values._triage`. `emergencyFlow`: hotline + turno urgente |
| `bot/src/flows/mainMenu.js` | Modificado | `distressGuard` en todos los keywords. `detect()` → triaje o redirect empático si ya tiene cita |
| `bot/src/index.js` | Modificado | Registra `triageFlow` + `emergencyFlow` al inicio del array |
| `bot/src/__tests__/services/triageService.test.cjs` | Nuevo | 12 tests: nextTurn (primer turno, último turno, error fallback), finalize (4 rangos + boundary 27), saveAssessment, hasUpcomingAppointment |

### Comportamiento

**Activación del triaje:**
- Usuario escribe "hola", "menu", "ayuda" → `detect(text)` evalúa angustia
- Si angustia detectada **Y** sin turno en las próximas 48h → `gotoFlow(triageFlow)`
- Si angustia detectada **Y** tiene turno → mensaje empático recordando la cita

**Flujo triaje:**
- Intro empática → 9 preguntas PHQ-9 como conversación natural (GPT-4o `completeJSON`)
- Estado persiste en `contact.values._triage` (JSONB) — sobrevive reinicios
- Al finalizar: score acumulado → urgency level → `saveAssessment` → `triage_assessments`
  - minimal (0-4) / mild (5-9): recomendación de consulta
  - moderate (10-14): agendar pronto
  - severe (15-27): `emergencyFlow` → hotline (`CRISIS_HOTLINE` env, fallback 106/192 Colombia) + turno urgente

### Tests
66/66 pass (54 PR1+PR2 + 12 nuevos triageService)

### Pre-requisitos
- Migration `014_triage_assessments.sql` aplicada en Railway antes del merge